### PR TITLE
Github relative

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -138,10 +139,17 @@ func doGet(c *cli.Context) {
 	// Find repository name trailing after github.com/USER/. 
 	if !strings.Contains(argURL, "/") {
 		if wd, err := os.Getwd(); err == nil {
+			wd = filepath.ToSlash(wd)
+			if runtime.GOOS == "windows" {
+				wd = strings.ToLower(wd)
+			}
 			m := regexp.MustCompile(`/github.com/[^\/]+$`).FindStringIndex(wd)
 			if len(m) > 1 {
 				base, tail := wd[:m[0]], wd[m[0]+1:]
 				for _, root := range localRepositoryRoots() {
+					if runtime.GOOS == "windows" {
+						root = filepath.ToSlash(strings.ToLower(root))
+					}
 					if root == base {
 						argURL = "https://" + tail + "/" + argURL
 						break

--- a/commands_test.go
+++ b/commands_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 import (
-	"testing"
 	. "github.com/onsi/gomega"
+	"testing"
 )
 
 func flagSet(name string, flags []cli.Flag) *flag.FlagSet {

--- a/commands_test.go
+++ b/commands_test.go
@@ -102,7 +102,7 @@ func withFakeGitBackend(t *testing.T, block func(string, *_cloneArgs, *_updateAr
 		Clone: func(remote *url.URL, local string, shallow bool) error {
 			cloneArgs = _cloneArgs{
 				remote:  remote,
-				local:   local,
+				local:   filepath.FromSlash(local),
 				shallow: shallow,
 			}
 			return nil

--- a/commands_test.go
+++ b/commands_test.go
@@ -171,6 +171,19 @@ func TestCommandGet(t *testing.T) {
 		Expect(cloneArgs.local).To(Equal(localDir))
 		Expect(cloneArgs.shallow).To(Equal(true))
 	})
+
+	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+		localDir := filepath.Join(tmpRoot, "github.com", "motemen")
+		os.MkdirAll(localDir, 0755)
+		wd, _ := os.Getwd()
+		defer os.Chdir(wd)
+		os.Chdir(localDir)
+
+		app.Run([]string{"", "get", "-u", "ghq-test-repo"})
+
+		Expect(cloneArgs.remote.String()).To(Equal("https://github.com/motemen/ghq-test-repo"))
+		Expect(cloneArgs.local).To(Equal(filepath.Join(localDir, "ghq-test-repo")))
+	})
 }
 
 func TestCommandList(t *testing.T) {

--- a/git_test.go
+++ b/git_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	. "github.com/onsi/gomega"
+	"testing"
 )
 
 func TestGitConfigAll(t *testing.T) {

--- a/url_test.go
+++ b/url_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	. "github.com/onsi/gomega"
 	"net/url"
 	"testing"
-	. "github.com/onsi/gomega"
 )
 
 func TestNewURL(t *testing.T) {


### PR DESCRIPTION
When here is `/path/to/ghq/root/github.com/motemen` and do `ghq get git-pr-release`, `github.com/motemen/git-pr-release` should be expected repository name.