### PR TITLE
Add GHQ_LOOK env variable to a new shell executed by `ghq look`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -309,7 +309,8 @@ func doLook(c *cli.Context) {
 			err := os.Chdir(reposFound[0].FullPath)
 			utils.PanicIf(err)
 
-			syscall.Exec(shell, []string{shell}, syscall.Environ())
+			env := append(syscall.Environ(), "GHQ_LOOK="+reposFound[0].RelPath)
+			syscall.Exec(shell, []string{shell}, env)
 		}
 
 	default:


### PR DESCRIPTION
I want to use the relpath of found local repository on a new shell executed by `ghq look`.
An example is as follows:
```sh
# .zshrc
if [ -n "$GHQ_LOOK" ]; then
    export PROMPT="[$GHQ_LOOK] $PROMPT"
fi
```

<!---
@huboard:{"order":47.0,"milestone_order":47,"custom_state":""}
-->
