### PR TITLE
`look` command accepts remote repository url too.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -282,6 +282,20 @@ func doLook(c *cli.Context) {
 		}
 	})
 
+	if len(reposFound) == 0 {
+		url, err := NewURL(name)
+
+		if err == nil {
+			repo := LocalRepositoryFromURL(url)
+			_, err := os.Stat(repo.FullPath)
+
+			// if the directory exists
+			if err == nil {
+				reposFound = append(reposFound, repo)
+			}
+		}
+	}
+
 	switch len(reposFound) {
 	case 0:
 		utils.Log("error", "No repository found")


### PR DESCRIPTION
This PR make `look` command accept remote repository url.

## Usecase

Cloning a repository and changing to the directory with one command like the following:

```bash
getrepo() {
  ghq get $1
  ghq look $1
}

getrepo git@github.com:motemen/ghq.git
```