### PR TITLE
Skip non-VCS directories for performance

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -136,9 +136,14 @@ func walkLocalRepositories(callback func(*LocalRepository)) {
 	for _, root := range localRepositoryRoots() {
 		filepath.Walk(root, func(path string, fileInfo os.FileInfo, err error) error {
 			if err != nil || fileInfo == nil || fileInfo.IsDir() == false {
-				return nil
+				// ghq.root can contain regular files.
+				if root == filepath.Dir(path) {
+					return nil
+				}
+				// If a regular file was found in a non-root directory, the directory
+				// shouldn't be a repository.
+				return filepath.SkipDir
 			}
-
 			vcsDirFound := false
 			for _, d := range vcsDirs {
 				_, err := os.Stat(filepath.Join(path, d))


### PR DESCRIPTION
Suppose there are some non-VCS managed directories under `ghq.root`, `ghq` traveses all such directories recursively. It can be quite time consuming if they contain a lot of files and/or directories.

Instead, we can prune the further traverse when `ghq` finds a regular file in a non-VCS managed directory. I excluded `ghq.root` from the pruning because I typically have tarballs along with the non-VCS managed directories there.

Here is a comparison between with and without the change.
```
% time ghq list > /dev/null  
ghq list > /dev/null  1.46s user 19.63s system 88% cpu 23.874 total
% time ./ghq list > /dev/null
./ghq list > /dev/null  0.01s user 0.01s system 32% cpu 0.054 total
```