### PR TITLE
Add darcs backend

### DIFF
--- a/ghq.txt
+++ b/ghq.txt
@@ -78,7 +78,8 @@ ghq.<url>.vcs::
     repositories.  With this option you can explicitly specify the VCS for the
     remote repository. The URL is matched against '<url>' using 'git config --get-urlmatch'. +
     Accepted values are "git", "github" (an alias for "git"), "subversion",
-    "svn" (an alias for "subversion"), "git-svn", "mercurial", "hg" (an alias for "mercurial"). +
+    "svn" (an alias for "subversion"), "git-svn", "mercurial", "hg" (an alias for "mercurial"),
+    and "darcs". +
     To get this configuration variable effective, you will need Git 1.8.5 or higher. +
     For example in .gitconfig:
 

--- a/local_repository.go
+++ b/local_repository.go
@@ -127,10 +127,15 @@ func (repo *LocalRepository) VCS() *VCSBackend {
 		return MercurialBackend
 	}
 
+	fi, err = os.Stat(filepath.Join(repo.FullPath, "_darcs"))
+	if err == nil && fi.IsDir() {
+		return DarcsBackend
+	}
+
 	return nil
 }
 
-var vcsDirs = []string{".git", ".svn", ".hg"}
+var vcsDirs = []string{".git", ".svn", ".hg", "_darcs"}
 
 func walkLocalRepositories(callback func(*LocalRepository)) {
 	for _, root := range localRepositoryRoots() {

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -125,6 +125,10 @@ func (repo *OtherRepository) VCS() *VCSBackend {
 		if vcs == "hg" || vcs == "mercurial" {
 			return MercurialBackend
 		}
+
+		if vcs == "darcs" {
+			return DarcsBackend
+		}
 	} else {
 		utils.Log("warning", "This version of Git does not support `config --get-urlmatch`; per-URL settings are not available")
 	}

--- a/utils/log.go
+++ b/utils/log.go
@@ -8,11 +8,12 @@ import (
 
 var logger = &colorine.Logger{
 	colorine.Prefixes{
-		"git":  colorine.Verbose,
-		"hg":   colorine.Verbose,
-		"svn":  colorine.Verbose,
-		"skip": colorine.Verbose,
-		"cd":   colorine.Verbose,
+		"git":   colorine.Verbose,
+		"hg":    colorine.Verbose,
+		"svn":   colorine.Verbose,
+		"darcs": colorine.Verbose,
+		"skip":  colorine.Verbose,
+		"cd":    colorine.Verbose,
 
 		"open":    colorine.Warn,
 		"exists":  colorine.Warn,

--- a/vcs.go
+++ b/vcs.go
@@ -89,3 +89,24 @@ var MercurialBackend = &VCSBackend{
 		return utils.RunInDir(local, "hg", "pull", "--update")
 	},
 }
+
+var DarcsBackend = &VCSBackend{
+	Clone: func(remote *url.URL, local string, shallow bool) error {
+		dir, _ := filepath.Split(local)
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+
+		args := []string{"get"}
+		if shallow {
+			args = append(args, "--lazy")
+		}
+		args = append(args, remote.String(), local)
+
+		return utils.Run("darcs", args...)
+	},
+	Update: func(local string) error {
+		return utils.RunInDir(local, "darcs", "pull")
+	},
+}


### PR DESCRIPTION
This patch adds darcs backend. I didn't implement automatic darcs detection because darcs doesn't seem to have the equivalent of `ls-remote`.

Example session:
```
% grep -A2 ghq ~/.gitconfig
[ghq]
    root = ~/src
[ghq "http://hub.darcs.net/"]
    vcs = darcs
% ./ghq get http://hub.darcs.net/byorgey/split
     clone http://hub.darcs.net/byorgey/split -> /Users/maoe/src/hub.darcs.net/byorgey/split
     darcs get http://hub.darcs.net/byorgey/split /Users/maoe/src/hub.darcs.net/byorgey/split
Copying patches, to get lazy repository hit ctrl-C...
Finished getting.
```