### PR TITLE
Support for Bluemix DevOps Git service

### DIFF
--- a/remote_repository.go
+++ b/remote_repository.go
@@ -103,6 +103,24 @@ func (repo *DarksHubRepository) VCS() *VCSBackend {
 	return DarcsBackend
 }
 
+type BluemixRepository struct {
+	url *url.URL
+}
+
+func (repo *BluemixRepository) URL() *url.URL {
+	return repo.url
+}
+
+var validBluemixPathPattern = regexp.MustCompile(`^/git/[^/]+/[^/]+$`)
+
+func (repo *BluemixRepository) IsValid() bool {
+	return validBluemixPathPattern.MatchString(repo.url.Path)
+}
+
+func (repo *BluemixRepository) VCS() *VCSBackend {
+	return GitBackend
+}
+
 type OtherRepository struct {
 	url *url.URL
 }
@@ -176,6 +194,10 @@ func NewRemoteRepository(url *url.URL) (RemoteRepository, error) {
 
 	if url.Host == "hub.darcs.net" {
 		return &DarksHubRepository{url}, nil
+	}
+
+	if url.Host == "hub.jazz.net" {
+		return &BluemixRepository{url}, nil
 	}
 
 	gheHosts, err := GitConfigAll("ghq.ghe.host")


### PR DESCRIPTION
Thank you for making great tool!
I created support for [Bluemix DevOps service](https://hub.jazz.net/).
Bluemix only supporting HTTPS so we need to show prompt.