### PR TITLE
it skips all repositories after a symlinked repository

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -175,7 +175,7 @@ func walkLocalRepositories(callback func(*LocalRepository)) {
 				return nil
 			}
 			callback(repo)
-			return filepath.SkipDir
+			return nil
 		})
 	}
 }

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -99,3 +99,33 @@ func TestList_Symlink(t *testing.T) {
 
 	Expect(paths).To(HaveLen(2))
 }
+
+func TestList_SymlinkedRepository(t *testing.T) {
+	RegisterTestingT(t)
+
+	root, err := ioutil.TempDir("", "")
+	Expect(err).To(BeNil())
+
+	for _, repo := range []string{"10hoge", "20hoge", "30hoge"} {
+		err := os.MkdirAll(filepath.Join(root, repo, ".git"), 0777)
+		Expect(err).To(BeNil())
+	}
+
+	originalDir, err := ioutil.TempDir("", "")
+	Expect(err).To(BeNil())
+
+	err = os.MkdirAll(filepath.Join(originalDir, ".git"), 0777)
+	Expect(err).To(BeNil())
+
+	err = os.Symlink(originalDir, filepath.Join(root, "15target"))
+	Expect(err).To(BeNil())
+
+	_localRepositoryRoots = []string{root}
+
+	paths := []string{}
+	walkLocalRepositories(func(repo *LocalRepository) {
+		paths = append(paths, repo.RelPath)
+	})
+
+	Expect(paths).To(Equal([]string{"10hoge", "15target", "20hoge", "30hoge"}))
+}


### PR DESCRIPTION
If the root directory has a symlinked repository, all repositories after that are skipped.

```sh
$ git config --get-all ghq.root
/tmp/hoge

$ mkdir -p /tmp/hoge/{10fuga,20fuga,30fuga}/.git

$ ls -l /tmp/hoge
total 0
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 10fuga
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 20fuga
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 30fuga

$ ghq list -p
/private/tmp/hoge/10fuga
/private/tmp/hoge/20fuga
/private/tmp/hoge/30fuga

$ mkdir -p /tmp/original/.git

$ ln -s /tmp/original /tmp/hoge/15target

$ ls -l /tmp/hoge
total 8
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 10fuga
lrwxr-xr-x 1 delphinus wheel  13 10 12 21:33 15target -> /tmp/original
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 20fuga
drwxr-xr-x 3 delphinus wheel 102 10 12 21:33 30fuga

$ ghq list -p
/private/tmp/hoge/10fuga
/private/tmp/hoge/15target

# 20fuga and 30fuga are disappeared!
```

In v0.6, this did not occur because symlinked directories are ignored in [this part][sym]. But by [this commit][commit], it started to scan symlinks and can reach [this `return`][return] if the symlinks have `vcsDirs` under themselves.

[sym]: https://github.com/motemen/ghq/blob/v0.6/local_repository.go#L138
[commit]: https://github.com/motemen/ghq/commit/50ab65cb6da7996d0c9ff17383ea35c1094a0ec7
[return]: https://github.com/motemen/ghq/blob/50ab65cb6da7996d0c9ff17383ea35c1094a0ec7/local_repository.go#L178

This `return` returns `filepath.SkipDir`, which has no means essentially if it would be a directory. I think it must reach this `return` if the path is a directory **or** a directory-like staff, so it does not need to return `filepath.SkipDir`.
