### PR TITLE
support path list in GHQ_ROOT

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -188,7 +188,7 @@ func localRepositoryRoots() []string {
 
 	envRoot := os.Getenv("GHQ_ROOT")
 	if envRoot != "" {
-		_localRepositoryRoots = []string{envRoot}
+		_localRepositoryRoots = strings.Split(envRoot, string(os.PathListSeparator))
 	} else {
 		var err error
 		_localRepositoryRoots, err = GitConfigAll("ghq.root")

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -63,12 +63,15 @@ func TestNewLocalRepository(t *testing.T) {
 func TestLocalRepositoryRoots(t *testing.T) {
 	RegisterTestingT(t)
 
-	_localRepositoryRoots = nil
-
 	defer func(orig string) { os.Setenv("GHQ_ROOT", orig) }(os.Getenv("GHQ_ROOT"))
-	os.Setenv("GHQ_ROOT", "/path/to/ghqroot")
 
+	_localRepositoryRoots = nil
+	os.Setenv("GHQ_ROOT", "/path/to/ghqroot")
 	Expect(localRepositoryRoots()).To(Equal([]string{"/path/to/ghqroot"}))
+
+	_localRepositoryRoots = nil
+	os.Setenv("GHQ_ROOT", "/path/to/ghqroot1"+string(os.PathListSeparator)+"/path/to/ghqroot2")
+	Expect(localRepositoryRoots()).To(Equal([]string{"/path/to/ghqroot1", "/path/to/ghqroot2"}))
 }
 
 // https://gist.github.com/kyanny/c231f48e5d08b98ff2c3


### PR DESCRIPTION
I want to use path list in GHQ_ROOT.

example
```
$ export GHQ_ROOT=/path/to/ghqroot1:/path/to/ghqroot2
$ ghq list -p
/paht/to/ghqroot1/github.com/motemen/ghq
/paht/to/ghqroot2/github.com/other/gqh
```