### PR TITLE
Fix deprecation warning of codegangsta/cli.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -125,7 +125,7 @@ OPTIONS:
 {{end}}`
 }
 
-func doGet(c *cli.Context) {
+func doGet(c *cli.Context) error {
 	argURL := c.Args().Get(0)
 	doUpdate := c.Bool("update")
 	isShallow := c.Bool("shallow")
@@ -177,6 +177,7 @@ func doGet(c *cli.Context) {
 	}
 
 	getRemoteRepository(remote, doUpdate, isShallow)
+	return nil
 }
 
 // getRemoteRepository clones or updates a remote repository remote.
@@ -222,7 +223,7 @@ func getRemoteRepository(remote RemoteRepository, doUpdate bool, isShallow bool)
 	}
 }
 
-func doList(c *cli.Context) {
+func doList(c *cli.Context) error {
 	query := c.Args().First()
 	exact := c.Bool("exact")
 	printFullPaths := c.Bool("full-path")
@@ -289,9 +290,10 @@ func doList(c *cli.Context) {
 			}
 		}
 	}
+	return nil
 }
 
-func doLook(c *cli.Context) {
+func doLook(c *cli.Context) error {
 	name := c.Args().First()
 
 	if name == "" {
@@ -357,9 +359,10 @@ func doLook(c *cli.Context) {
 			utils.Log("error", "- "+strings.Join(repo.PathParts, "/"))
 		}
 	}
+	return nil
 }
 
-func doImport(c *cli.Context) {
+func doImport(c *cli.Context) error {
 	var (
 		doUpdate  = c.Bool("update")
 		isSSH     = c.Bool("p")
@@ -437,9 +440,10 @@ func doImport(c *cli.Context) {
 	}
 
 	utils.DieIf(finalize())
+	return nil
 }
 
-func doRoot(c *cli.Context) {
+func doRoot(c *cli.Context) error {
 	all := c.Bool("all")
 	if all {
 		for _, root := range localRepositoryRoots() {
@@ -448,4 +452,5 @@ func doRoot(c *cli.Context) {
 	} else {
 		fmt.Println(primaryLocalRepositoryRoot())
 	}
+	return nil
 }


### PR DESCRIPTION
I've updated ghq today by `go get -u` command.
So, ghq says a warning to STDERR.

```sh
$ ghq list > /dev/null
DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
```



https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature


> the legacy signature for cli.App.Action of func(*cli.Context), which should now have a return signature of func(*cli.Context) error, as defined by cli.ActionFunc.


I've fixed this warning.


Versions
------

```sh
$ ghq --version
ghq version v0.7.4 (master)



$ cd $GOPATH/codegangsta/cli
$ git show
commit 839f07bfe4819fa1434fa907d0804ce6ec45a5df
Merge: b14dcdb cd92adc
Author: Jesse Szwedko <jesse.szwedko@gmail.com>
Date:   Mon May 2 21:17:00 2016 -0700

    Merge pull request #381 from codegangsta/pluggable-flag-printer
    
    Allow for pluggable flag-level help text formatting
```

