### PR TITLE
try git first when detecting VCS

### DIFF
--- a/remote_repository.go
+++ b/remote_repository.go
@@ -168,10 +168,10 @@ func (repo *OtherRepository) VCS() *VCSBackend {
 	}
 
 	// Detect VCS backend automatically
-	if utils.RunSilently("hg", "identify", repo.url.String()) == nil {
-		return MercurialBackend
-	} else if utils.RunSilently("git", "ls-remote", repo.url.String()) == nil {
+	if utils.RunSilently("git", "ls-remote", repo.url.String()) == nil {
 		return GitBackend
+	} else if utils.RunSilently("hg", "identify", repo.url.String()) == nil {
+		return MercurialBackend
 	} else if utils.RunSilently("svn", "info", repo.url.String()) == nil {
 		return SubversionBackend
 	} else {


### PR DESCRIPTION
It is reasonable change because there are more git repositories than hg.