### PR TITLE
Fix -X flag requires argument of the form importpath.name=value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERBOSE_FLAG = $(if $(VERBOSE),-v)
 VERSION = $$(git describe --tags --always --dirty) ($$(git name-rev --name-only HEAD))
 
 BUILD_FLAGS = -ldflags "\
-	      -X main.Version \"$(VERSION)\" \
+	      -X \"main.Version=$(VERSION)\" \
 	      "
 
 build: deps


### PR DESCRIPTION
On go version go1.8 darwin/amd64, make install failed with the following error.
```
$ make install
go get -d 
go install  -ldflags " -X main.Version \"$(git describe --tags --always --dirty) ($(git name-rev --name-only HEAD))\" "
# github.com/motemen/ghq
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/link: -X flag requires argument of the form importpath.name=value
make: *** [install] Error 2
```

This patch fixes the issue.