### PR TITLE
Update reference to codegangsta/cli to urfave/cli

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/motemen/ghq/utils"
 )
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 import (

--- a/ghq.txt
+++ b/ghq.txt
@@ -126,12 +126,12 @@ Local repositories are placed under 'ghq.root' with named github.com/_user_/_rep
 |   `-- p/
 |       `-- vim/
 `-- github.com/
-    |-- codegangsta/
-    |   `-- cli/
     |-- google/
     |   `-- go-github/
-    `-- motemen/
-        `-- ghq/
+    |-- motemen/
+    |   `-- ghq/
+    `-- urfave/
+        `-- cli/
 ....
 
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var Version string = "0.7.6"


### PR DESCRIPTION
codegangsta/cli is now renamed to urfave/cli, and they recommend
to update old reference.

> Notice: This is the library formerly known as github.com/codegangsta/cli -- Github will automatically redirect requests to this repository, but we recommend updating your references for clarity.

https://github.com/urfave/cli/blob/master/README.md

This patch will update reference to codegangsta/cli to urfave/cli.