### PR TITLE
Add parameter <directory> on ghq get

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -162,9 +162,28 @@ func TestCommandGet(t *testing.T) {
 	})
 
 	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "repo")
+
+		app.Run([]string{"", "get", "motemen/ghq-test-repo", "repo"})
+
+		Expect(cloneArgs.remote.String()).To(Equal("https://github.com/motemen/ghq-test-repo"))
+		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))
+		Expect(cloneArgs.shallow).To(Equal(false))
+	})
+
+	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
 
 		app.Run([]string{"", "get", "-p", "motemen/ghq-test-repo"})
+
+		Expect(cloneArgs.remote.String()).To(Equal("ssh://git@github.com/motemen/ghq-test-repo"))
+		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))
+	})
+
+	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "repo")
+
+		app.Run([]string{"", "get", "-p", "motemen/ghq-test-repo", "repo"})
 
 		Expect(cloneArgs.remote.String()).To(Equal("ssh://git@github.com/motemen/ghq-test-repo"))
 		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))
@@ -190,9 +209,28 @@ func TestCommandGet(t *testing.T) {
 	})
 
 	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "repo")
+		app.Run([]string{"", "get", "-p", "motemen/ghq-test-repo", "repo"})
+
+		Expect(cloneArgs.remote.String()).To(Equal("ssh://git@github.com/motemen/ghq-test-repo"))
+		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))
+		Expect(cloneArgs.shallow).To(Equal(false))
+	})
+
+	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
 
 		app.Run([]string{"", "get", "-shallow", "motemen/ghq-test-repo"})
+
+		Expect(cloneArgs.remote.String()).To(Equal("https://github.com/motemen/ghq-test-repo"))
+		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))
+		Expect(cloneArgs.shallow).To(Equal(true))
+	})
+
+	withFakeGitBackend(t, func(tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+		localDir := filepath.Join(tmpRoot, "github.com", "motemen", "repo")
+
+		app.Run([]string{"", "get", "-shallow", "motemen/ghq-test-repo", "repo"})
 
 		Expect(cloneArgs.remote.String()).To(Equal("https://github.com/motemen/ghq-test-repo"))
 		Expect(filepath.ToSlash(cloneArgs.local)).To(Equal(filepath.ToSlash(localDir)))

--- a/local_repository.go
+++ b/local_repository.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/motemen/ghq/utils"
+	"regexp"
 )
 
 type LocalRepository struct {
@@ -42,9 +43,19 @@ func LocalRepositoryFromFullPath(fullPath string) (*LocalRepository, error) {
 	return &LocalRepository{fullPath, filepath.ToSlash(relPath), pathParts}, nil
 }
 
-func LocalRepositoryFromURL(remoteURL *url.URL) *LocalRepository {
+var repositoryPathPattern = regexp.MustCompile(`^/(.+)/(.+)$`)
+
+func LocalRepositoryFromURL(remoteURL *url.URL, directory string) *LocalRepository {
+	localPath := remoteURL.Path
+	if directory != "" {
+		matched := repositoryPathPattern.FindStringSubmatch(remoteURL.Path)
+		username := matched[1]
+		reponame := matched[2]
+		localPath = strings.Replace(localPath, username + "/" + reponame, username + "/" + directory, -1)
+	}
+
 	pathParts := append(
-		[]string{remoteURL.Host}, strings.Split(remoteURL.Path, "/")...,
+		[]string{remoteURL.Host}, strings.Split(localPath, "/")...,
 	)
 	relPath := strings.TrimSuffix(path.Join(pathParts...), ".git")
 

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -28,35 +28,35 @@ func TestNewLocalRepository(t *testing.T) {
 	Expect(r.Subpaths()).To(Equal([]string{"ghq", "motemen/ghq", "scm/motemen/ghq", "stash.com/scm/motemen/ghq"}))
 
 	githubURL, _ := url.Parse("ssh://git@github.com/motemen/ghq.git")
-	r = LocalRepositoryFromURL(githubURL)
+	r = LocalRepositoryFromURL(githubURL, "")
 	Expect(r.FullPath).To(Equal("/repos/github.com/motemen/ghq"))
 
 	stashURL, _ := url.Parse("ssh://git@stash.com/scm/motemen/ghq")
-	r = LocalRepositoryFromURL(stashURL)
+	r = LocalRepositoryFromURL(stashURL, "")
 	Expect(r.FullPath).To(Equal("/repos/stash.com/scm/motemen/ghq"))
 
 	svnSourceforgeURL, _ := url.Parse("http://svn.code.sf.net/p/ghq/code/trunk")
-	r = LocalRepositoryFromURL(svnSourceforgeURL)
+	r = LocalRepositoryFromURL(svnSourceforgeURL, "")
 	Expect(r.FullPath).To(Equal("/repos/svn.code.sf.net/p/ghq/code/trunk"))
 
 	gitSourceforgeURL, _ := url.Parse("http://git.code.sf.net/p/ghq/code")
-	r = LocalRepositoryFromURL(gitSourceforgeURL)
+	r = LocalRepositoryFromURL(gitSourceforgeURL, "")
 	Expect(r.FullPath).To(Equal("/repos/git.code.sf.net/p/ghq/code"))
 
 	svnSourceforgeJpURL, _ := url.Parse("http://scm.sourceforge.jp/svnroot/ghq/")
-	r = LocalRepositoryFromURL(svnSourceforgeJpURL)
+	r = LocalRepositoryFromURL(svnSourceforgeJpURL, "")
 	Expect(r.FullPath).To(Equal("/repos/scm.sourceforge.jp/svnroot/ghq"))
 
 	gitSourceforgeJpURL, _ := url.Parse("http://scm.sourceforge.jp/gitroot/ghq/ghq.git")
-	r = LocalRepositoryFromURL(gitSourceforgeJpURL)
+	r = LocalRepositoryFromURL(gitSourceforgeJpURL, "")
 	Expect(r.FullPath).To(Equal("/repos/scm.sourceforge.jp/gitroot/ghq/ghq"))
 
 	svnAssemblaURL, _ := url.Parse("https://subversion.assembla.com/svn/ghq/")
-	r = LocalRepositoryFromURL(svnAssemblaURL)
+	r = LocalRepositoryFromURL(svnAssemblaURL, "")
 	Expect(r.FullPath).To(Equal("/repos/subversion.assembla.com/svn/ghq"))
 
 	gitAssemblaURL, _ := url.Parse("https://git.assembla.com/ghq.git")
-	r = LocalRepositoryFromURL(gitAssemblaURL)
+	r = LocalRepositoryFromURL(gitAssemblaURL, "")
 	Expect(r.FullPath).To(Equal("/repos/git.assembla.com/ghq"))
 }
 


### PR DESCRIPTION
Usage:
ghq get \<repository URL\> [\<directory\>]
ghq get \<user\>/\<project\> [\<directory\>]

You can specify project name with directory.
directory parmeter is optional.