### PR TITLE
Use parsed username also with ssh for Git

### DIFF
--- a/url.go
+++ b/url.go
@@ -48,7 +48,11 @@ func NewURL(ref string) (*url.URL, error) {
 }
 
 func ConvertGitURLHTTPToSSH(url *url.URL) (*url.URL, error) {
-	sshURL := fmt.Sprintf("ssh://git@%s%s", url.Host, url.Path)
+	user := url.User.Username()
+	if user == "" {
+		user = "git"
+	}
+	sshURL := fmt.Sprintf("ssh://%s@%s%s", user, url.Host, url.Path)
 	return url.Parse(sshURL)
 }
 

--- a/url.go
+++ b/url.go
@@ -48,9 +48,9 @@ func NewURL(ref string) (*url.URL, error) {
 }
 
 func ConvertGitURLHTTPToSSH(url *url.URL) (*url.URL, error) {
-	user := url.User.Username()
-	if user == "" {
-		user = "git"
+	user := "git";
+	if url.User != nil {
+		user = url.User.Username()
 	}
 	sshURL := fmt.Sprintf("ssh://%s@%s%s", user, url.Host, url.Path)
 	return url.Parse(sshURL)


### PR DESCRIPTION
This fixes #100, using `git` as username only when no username given.