### PR TITLE
add -l option on get command which immediately look after get

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -27,6 +27,7 @@ var cloneFlags = []cli.Flag{
 	cli.BoolFlag{Name: "update, u", Usage: "Update local repository if cloned already"},
 	cli.BoolFlag{Name: "p", Usage: "Clone with SSH"},
 	cli.BoolFlag{Name: "shallow", Usage: "Do a shallow clone"},
+	cli.BoolFlag{Name: "look, l", Usage: "Look after get"},
 }
 
 var commandGet = cli.Command{
@@ -129,6 +130,7 @@ func doGet(c *cli.Context) error {
 	argURL := c.Args().Get(0)
 	doUpdate := c.Bool("update")
 	isShallow := c.Bool("shallow")
+	andLook := c.Bool("look")
 
 	if argURL == "" {
 		cli.ShowCommandHelp(c, "get")
@@ -177,6 +179,9 @@ func doGet(c *cli.Context) error {
 	}
 
 	getRemoteRepository(remote, doUpdate, isShallow)
+	if andLook {
+		doLook(c)
+	}
 	return nil
 }
 


### PR DESCRIPTION
```
ghq get -l motemen/ghq
```
which clones the repository and instantly look into the directory.
Also, this command line is reusable.
You never wonder if the repository has been cloned or not.
