### PR TITLE
Make commandRoot --all flag is true by default

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -81,7 +81,7 @@ var commandRoot = cli.Command{
 	Usage:  "Show repositories' root",
 	Action: doRoot,
 	Flags: []cli.Flag{
-		cli.BoolFlag{Name: "all", Usage: "Show all roots"},
+		cli.BoolTFlag{Name: "all", Usage: "Show all roots"},
 	},
 }
 


### PR DESCRIPTION
This closes #113.

```
$ echo $GHQ_ROOT
/Users/szyn/ghq/src:/Users/szyn/go/src

$ ghq root
/Users/szyn/ghq/src
/Users/szyn/go/src

$ ghq root --all=false
/Users/szyn/ghq/src
```