### PR TITLE
Add remove command

### DIFF
--- a/ghq.txt
+++ b/ghq.txt
@@ -22,6 +22,7 @@ You can also list local repositories (+ghq list+), jump into local repositories 
 'ghq' import [-u] [-p] < FILE
 'ghq' import <subcommand> [<args>...]
 'ghq' root [--all]
+'ghq' remove (<project> | <path/to/project>) [--force]
 
 == COMMANDS
 
@@ -60,6 +61,11 @@ import::
 root::
     Prints repositories' root (i.e. `ghq.root`). Without '--all' option, the
     primary one is shown.
+
+remove::
+    Removes a repository from under ghq.root. Without the --force option, will
+    only allow a user to remove a directory directly under VCS. The force option
+    allows the user to remove any directory from under ghq.root.
 
 == CONFIGURATION
 

--- a/vcs.go
+++ b/vcs.go
@@ -10,13 +10,20 @@ import (
 
 // A VCSBackend represents a VCS backend.
 type VCSBackend struct {
+	// Name of the specific VCSBackend type
+	Type string
 	// Clones a remote repository to local path.
 	Clone func(*url.URL, string, bool) error
 	// Updates a cloned local repository.
 	Update func(string) error
 }
 
+func (v VCSBackend) String() string {
+	return v.Type
+}
+
 var GitBackend = &VCSBackend{
+	Type: "git",
 	Clone: func(remote *url.URL, local string, shallow bool) error {
 		dir, _ := filepath.Split(local)
 		err := os.MkdirAll(dir, 0755)
@@ -38,6 +45,7 @@ var GitBackend = &VCSBackend{
 }
 
 var SubversionBackend = &VCSBackend{
+	Type: "subversion",
 	Clone: func(remote *url.URL, local string, shallow bool) error {
 		dir, _ := filepath.Split(local)
 		err := os.MkdirAll(dir, 0755)
@@ -59,6 +67,7 @@ var SubversionBackend = &VCSBackend{
 }
 
 var GitsvnBackend = &VCSBackend{
+	Type: "git-svn",
 	// git-svn seems not supporting shallow clone currently.
 	Clone: func(remote *url.URL, local string, ignoredShallow bool) error {
 		dir, _ := filepath.Split(local)
@@ -75,6 +84,7 @@ var GitsvnBackend = &VCSBackend{
 }
 
 var MercurialBackend = &VCSBackend{
+	Type: "mercurial",
 	// Mercurial seems not supporting shallow clone currently.
 	Clone: func(remote *url.URL, local string, ignoredShallow bool) error {
 		dir, _ := filepath.Split(local)
@@ -91,6 +101,7 @@ var MercurialBackend = &VCSBackend{
 }
 
 var DarcsBackend = &VCSBackend{
+	Type: "darcs",
 	Clone: func(remote *url.URL, local string, shallow bool) error {
 		dir, _ := filepath.Split(local)
 		err := os.MkdirAll(dir, 0755)


### PR DESCRIPTION
This adds a command to remove a repository from `ghq.root` via the `remove` command, e.g. `ghq remove foo` would remove the directory `$GHQ_ROOT/github.com/user/foo`.

While testing, I found that if the repository I tried to remove was something like `user/` and a repository that was found via the `LocalRepositoryFromURL` method it would remove that directory without question. So I instead added a `--force` command to ensure that this is actually what the user wants e.g. the scenario below:

- I have three directories in `ghq.root`: `$GHQ_ROOT/github.com/user/{foo,bar,baz}`
- I run `ghq remove user/`
- This matches on the `$GHQ_ROOT/github.com/user/` directory
- This should warn the user that this is a top level directory i.e. one that contains others - so they must add `--force` in order to remove it.
- The user runs `ghq remove --force user/`
- The directory `$GHQ_ROOT/github.com/user/` is removed

See below for some examples:

```lua
w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % make
go get -d
go build  -ldflags " -X \"main.Version=$(git describe --tags --always --dirty) ($(git name-rev --name-only HEAD))\" "

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % ./ghq list
github.com/w1lkins/foo
github.com/w1lkins/dotfiles
github.com/w1lkins/ghq

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % ./ghq remove foo
        rm /home/jwilkins/workspace/github.com/w1lkins/foo

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % ./ghq list
github.com/w1lkins/dotfiles
github.com/w1lkins/ghq

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % ./ghq get firecracker-microvm/firecracker
     clone https://github.com/firecracker-microvm/firecracker -> /home/jwilkins/workspace/github.com/firecracker-microvm/firecracker
       git clone https://github.com/firecracker-microvm/firecracker /home/jwilkins/workspace/github.com/firecracker-microvm/firecracker
Cloning into '/home/jwilkins/workspace/github.com/firecracker-microvm/firecracker'...

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[0] % ./ghq remove firecracker-microvm/
   warning /home/jwilkins/workspace/github.com/firecracker-microvm looks like a top level directory
   warning If you are sure this is what you want, run remove with the --force flag to remove it

w1lkins@nuc ‹ add-remove-command › : ~/workspace/github.com/w1lkins/ghq
[1] % ./ghq remove --force firecracker-microvm/
        rm /home/jwilkins/workspace/github.com/firecracker-microvm
```

I also made sure to test this on a Windows machine.