### PR TITLE
Add ghq.completeUser config to disable user completion of `ghq get`

### DIFF
--- a/url.go
+++ b/url.go
@@ -53,6 +53,14 @@ func ConvertGitURLHTTPToSSH(url *url.URL) (*url.URL, error) {
 }
 
 func fillUsernameToPath(path string) (string, error) {
+	completeUser, err := GitConfigSingle("ghq.completeUser")
+	if err != nil {
+		return path, err
+	}
+	if completeUser == "false" {
+		return path + "/" + path, nil
+	}
+
 	user, err := GitConfigSingle("ghq.user")
 	if err != nil {
 		return path, err


### PR DESCRIPTION
## Problem
Prior to v0.8.0 https://github.com/motemen/ghq/pull/81, I had used `ghq get repo` to clone `repo/repo`. The behavior was convenient for cloning some repositories like git/git, ruby/ruby, rails/rails, peco/peco, vim/vim, haml/haml, bundler/bundler, rack/rack, etc., as described in https://github.com/motemen/ghq/pull/14.

I'd like to use the feature again because I usually clone all of my repositories at once and rarely clone my repository with `ghq get`. Also I often get confused by trying to use the old behavior, even after 2 years.

## Solution

I'd like to introduce a git config to resurrect the original behavior:

```gitconfig
[ghq]
  completeUser = false
```

With this config, `ghq get repo` clones repo/repo. By default it's considered as `true` and this PR is backward-compatible.

Note that `completeuser = false` also works by the nature of `git config`.