### PR TITLE
support refs which start with URL Authority in ghq get

### DIFF
--- a/url_test.go
+++ b/url_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	. "github.com/onsi/gomega"
 	"net/url"
 	"os"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestNewURL(t *testing.T) {
@@ -35,6 +36,16 @@ func TestNewURL(t *testing.T) {
 	differentNameRepository, err := NewURL("motemen/ghq")
 	Expect(differentNameRepository.String()).To(Equal("https://github.com/motemen/ghq"))
 	Expect(differentNameRepository.Host).To(Equal("github.com"))
+	Expect(err).To(BeNil())
+
+	withAuthorityRepository, err := NewURL("github.com/motemen/gore")
+	Expect(withAuthorityRepository.String()).To(Equal("https://github.com/motemen/gore"))
+	Expect(withAuthorityRepository.Host).To(Equal("github.com"))
+	Expect(err).To(BeNil())
+
+	withAuthorityRepository2, err := NewURL("golang.org/x/crypto")
+	Expect(withAuthorityRepository2.String()).To(Equal("https://golang.org/x/crypto"))
+	Expect(withAuthorityRepository2.Host).To(Equal("golang.org"))
 	Expect(err).To(BeNil())
 
 	os.Setenv("GITHUB_USER", "ghq-test")


### PR DESCRIPTION
## Before

```console
% ghq get github.com/motemen/ghq
    error Not a valid repository: https://github.com/github.com/motemen/ghq
```

## After

```console
% ghq get github.com/motemen/ghq
    exists /Users/Songmu/dev/src/github.com/motemen/ghq
```

Next, I plan to enable `ghq get golang.org/x/crypto` etc according to `meta="go-import"` rules. > #120