### PR TITLE
support `meta name="go-import"` to detect Go repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.8
-  - 1.9
+  - 1.x
   - tip
 
 script: make test VERBOSE=1

--- a/commands.go
+++ b/commands.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/urfave/cli"
 	"github.com/motemen/ghq/utils"
+	"github.com/urfave/cli"
 )
 
 var Commands = []cli.Command{
@@ -202,13 +202,13 @@ func getRemoteRepository(remote RemoteRepository, doUpdate bool, isShallow bool)
 	if newPath {
 		utils.Log("clone", fmt.Sprintf("%s -> %s", remoteURL, path))
 
-		vcs := remote.VCS()
+		vcs, repoURL := remote.VCS()
 		if vcs == nil {
 			utils.Log("error", fmt.Sprintf("Could not find version control system: %s", remoteURL))
 			os.Exit(1)
 		}
 
-		err := vcs.Clone(remoteURL, path, isShallow)
+		err := vcs.Clone(repoURL, path, isShallow)
 		if err != nil {
 			utils.Log("error", err.Error())
 			os.Exit(1)

--- a/go_import.go
+++ b/go_import.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+func detectGoImport(u *url.URL) (string, *url.URL, error) {
+	goGetU, _ := url.Parse(u.String()) // clone
+	q := goGetU.Query()
+	q.Add("go-get", "1")
+	goGetU.RawQuery = q.Encode()
+
+	cli := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// never follow redirection
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, goGetU.String(), nil)
+	req.Header.Add("User-Agent", fmt.Sprintf("ghq/%s (+https://github.com/motemen/ghq)", Version))
+	resp, err := cli.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	return detectVCSAndRepoURL(resp.Body)
+}
+
+// find meta tag like following from thml
+// <meta name="go-import" content="gopkg.in/yaml.v2 git https://gopkg.in/yaml.v2">
+// ref. https://golang.org/cmd/go/#hdr-Remote_import_paths
+func detectVCSAndRepoURL(r io.Reader) (string, *url.URL, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var goImportContent string
+
+	var f func(*html.Node)
+	f = func(n *html.Node) {
+		if goImportContent != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "meta" {
+			var (
+				goImportMeta = false
+				content      = ""
+			)
+			for _, a := range n.Attr {
+				if a.Key == "name" && a.Val == "go-import" {
+					goImportMeta = true
+					continue
+				}
+				if a.Key == "content" {
+					content = a.Val
+				}
+			}
+			if goImportMeta && content != "" {
+				goImportContent = content
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
+		}
+	}
+	f(doc)
+
+	stuffs := strings.Fields(goImportContent)
+	if len(stuffs) < 3 {
+		return "", nil, fmt.Errorf("no go-import meta tags detected")
+	}
+	u, err := url.Parse(stuffs[2])
+	if err != nil {
+		return "", nil, err
+	}
+	return stuffs[1], u, nil
+}

--- a/go_import_test.go
+++ b/go_import_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectVCSAndRepoURL(t *testing.T) {
+	input := `<html>
+<head>
+<meta name="go-import" content="gopkg.in/yaml.v2 git https://gopkg.in/yaml.v2">
+<meta name="go-source" content="gopkg.in/yaml.v2 _ https://github.com/go-yaml/yaml/tree/v2.2.2{/dir} https://github.com/go-yaml/yaml/blob/v2.2.2{/dir}/{file}#L{line}">
+</head>
+<body>
+go get gopkg.in/yaml.v2
+</body>
+</html>`
+
+	vcs, u, err := detectVCSAndRepoURL(strings.NewReader(input))
+	if vcs != "git" {
+		t.Errorf("want: %q, got: %q", "git", vcs)
+	}
+	expectedURL := "https://gopkg.in/yaml.v2"
+	if u.String() != expectedURL {
+		t.Errorf("want: %q, got: %q", expectedURL, u.String())
+	}
+	if err != nil {
+		t.Errorf("something went wrong: %s", err)
+	}
+}

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -16,7 +16,7 @@ type RemoteRepository interface {
 	// Checks if the URL is valid.
 	IsValid() bool
 	// The VCS backend that hosts the repository.
-	VCS() *VCSBackend
+	VCS() (*VCSBackend, *url.URL)
 }
 
 // A GitHubRepository represents a GitHub repository. Impliments RemoteRepository.
@@ -42,8 +42,8 @@ func (repo *GitHubRepository) IsValid() bool {
 	return true
 }
 
-func (repo *GitHubRepository) VCS() *VCSBackend {
-	return GitBackend
+func (repo *GitHubRepository) VCS() (*VCSBackend, *url.URL) {
+	return GitBackend, repo.URL()
 }
 
 // A GitHubGistRepository represents a GitHub Gist repository.
@@ -59,8 +59,8 @@ func (repo *GitHubGistRepository) IsValid() bool {
 	return true
 }
 
-func (repo *GitHubGistRepository) VCS() *VCSBackend {
-	return GitBackend
+func (repo *GitHubGistRepository) VCS() (*VCSBackend, *url.URL) {
+	return GitBackend, repo.URL()
 }
 
 type GoogleCodeRepository struct {
@@ -77,13 +77,13 @@ func (repo *GoogleCodeRepository) IsValid() bool {
 	return validGoogleCodePathPattern.MatchString(repo.url.Path)
 }
 
-func (repo *GoogleCodeRepository) VCS() *VCSBackend {
+func (repo *GoogleCodeRepository) VCS() (*VCSBackend, *url.URL) {
 	if utils.RunSilently("hg", "identify", repo.url.String()) == nil {
-		return MercurialBackend
+		return MercurialBackend, repo.URL()
 	} else if utils.RunSilently("git", "ls-remote", repo.url.String()) == nil {
-		return GitBackend
+		return GitBackend, repo.URL()
 	} else {
-		return nil
+		return nil, nil
 	}
 }
 
@@ -99,8 +99,8 @@ func (repo *DarksHubRepository) IsValid() bool {
 	return strings.Count(repo.url.Path, "/") == 2
 }
 
-func (repo *DarksHubRepository) VCS() *VCSBackend {
-	return DarcsBackend
+func (repo *DarksHubRepository) VCS() (*VCSBackend, *url.URL) {
+	return DarcsBackend, repo.URL()
 }
 
 type BluemixRepository struct {
@@ -117,8 +117,8 @@ func (repo *BluemixRepository) IsValid() bool {
 	return validBluemixPathPattern.MatchString(repo.url.Path)
 }
 
-func (repo *BluemixRepository) VCS() *VCSBackend {
-	return GitBackend
+func (repo *BluemixRepository) VCS() (*VCSBackend, *url.URL) {
+	return GitBackend, repo.URL()
 }
 
 type OtherRepository struct {
@@ -133,7 +133,7 @@ func (repo *OtherRepository) IsValid() bool {
 	return true
 }
 
-func (repo *OtherRepository) VCS() *VCSBackend {
+func (repo *OtherRepository) VCS() (*VCSBackend, *url.URL) {
 	if GitHasFeatureConfigURLMatch() {
 		// Respect 'ghq.url.https://ghe.example.com/.vcs' config variable
 		// (in gitconfig:)
@@ -145,23 +145,23 @@ func (repo *OtherRepository) VCS() *VCSBackend {
 		}
 
 		if vcs == "git" || vcs == "github" {
-			return GitBackend
+			return GitBackend, repo.URL()
 		}
 
 		if vcs == "svn" || vcs == "subversion" {
-			return SubversionBackend
+			return SubversionBackend, repo.URL()
 		}
 
 		if vcs == "git-svn" {
-			return GitsvnBackend
+			return GitsvnBackend, repo.URL()
 		}
 
 		if vcs == "hg" || vcs == "mercurial" {
-			return MercurialBackend
+			return MercurialBackend, repo.URL()
 		}
 
 		if vcs == "darcs" {
-			return DarcsBackend
+			return DarcsBackend, repo.URL()
 		}
 	} else {
 		utils.Log("warning", "This version of Git does not support `config --get-urlmatch`; per-URL settings are not available")
@@ -169,13 +169,13 @@ func (repo *OtherRepository) VCS() *VCSBackend {
 
 	// Detect VCS backend automatically
 	if utils.RunSilently("git", "ls-remote", repo.url.String()) == nil {
-		return GitBackend
+		return GitBackend, repo.URL()
 	} else if utils.RunSilently("hg", "identify", repo.url.String()) == nil {
-		return MercurialBackend
+		return MercurialBackend, repo.URL()
 	} else if utils.RunSilently("svn", "info", repo.url.String()) == nil {
-		return SubversionBackend
+		return SubversionBackend, repo.URL()
 	} else {
-		return nil
+		return nil, nil
 	}
 }
 

--- a/remote_repository_test.go
+++ b/remote_repository_test.go
@@ -28,12 +28,14 @@ func TestNewRemoteRepositoryGitHub(t *testing.T) {
 	repo, err = NewRemoteRepository(parseURL("https://github.com/motemen/pusheen-explorer"))
 	Expect(err).To(BeNil())
 	Expect(repo.IsValid()).To(Equal(true))
-	Expect(repo.VCS()).To(Equal(GitBackend))
+	vcs, _ := repo.VCS()
+	Expect(vcs).To(Equal(GitBackend))
 
 	repo, err = NewRemoteRepository(parseURL("https://github.com/motemen/pusheen-explorer/"))
 	Expect(err).To(BeNil())
 	Expect(repo.IsValid()).To(Equal(true))
-	Expect(repo.VCS()).To(Equal(GitBackend))
+	vcs, _ = repo.VCS()
+	Expect(vcs).To(Equal(GitBackend))
 
 	repo, err = NewRemoteRepository(parseURL("https://github.com/motemen/pusheen-explorer/blob/master/README.md"))
 	Expect(err).To(BeNil())
@@ -55,7 +57,8 @@ func TestNewRemoteRepositoryGitHubGist(t *testing.T) {
 	repo, err = NewRemoteRepository(parseURL("https://gist.github.com/motemen/9733745"))
 	Expect(err).To(BeNil())
 	Expect(repo.IsValid()).To(Equal(true))
-	Expect(repo.VCS()).To(Equal(GitBackend))
+	vcs, _ := repo.VCS()
+	Expect(vcs).To(Equal(GitBackend))
 }
 
 func TestNewRemoteRepositoryGoogleCode(t *testing.T) {
@@ -73,7 +76,8 @@ func TestNewRemoteRepositoryGoogleCode(t *testing.T) {
 		"hg identify":   nil,
 		"git ls-remote": errors.New(""),
 	})
-	Expect(repo.VCS()).To(Equal(MercurialBackend))
+	vcs, _ := repo.VCS()
+	Expect(vcs).To(Equal(MercurialBackend))
 
 	repo, err = NewRemoteRepository(parseURL("https://code.google.com/p/git-core"))
 	Expect(err).To(BeNil())
@@ -82,7 +86,8 @@ func TestNewRemoteRepositoryGoogleCode(t *testing.T) {
 		"hg identify":   errors.New(""),
 		"git ls-remote": nil,
 	})
-	Expect(repo.VCS()).To(Equal(GitBackend))
+	vcs, _ = repo.VCS()
+	Expect(vcs).To(Equal(GitBackend))
 }
 
 func TestNewRemoteRepositoryDarcsHub(t *testing.T) {
@@ -91,5 +96,6 @@ func TestNewRemoteRepositoryDarcsHub(t *testing.T) {
 	repo, err := NewRemoteRepository(parseURL("http://hub.darcs.net/foo/bar"))
 	Expect(err).To(BeNil())
 	Expect(repo.IsValid()).To(Equal(true))
-	Expect(repo.VCS()).To(Equal(DarcsBackend))
+	vcs, _ := repo.VCS()
+	Expect(vcs).To(Equal(DarcsBackend))
 }

--- a/url_test.go
+++ b/url_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	. "github.com/onsi/gomega"
 	"net/url"
 	"os"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestNewURL(t *testing.T) {
@@ -35,6 +36,16 @@ func TestNewURL(t *testing.T) {
 	differentNameRepository, err := NewURL("motemen/ghq")
 	Expect(differentNameRepository.String()).To(Equal("https://github.com/motemen/ghq"))
 	Expect(differentNameRepository.Host).To(Equal("github.com"))
+	Expect(err).To(BeNil())
+
+	withAuthorityRepository, err := NewURL("github.com/motemen/gore")
+	Expect(withAuthorityRepository.String()).To(Equal("https://github.com/motemen/gore"))
+	Expect(withAuthorityRepository.Host).To(Equal("github.com"))
+	Expect(err).To(BeNil())
+
+	withAuthorityRepository2, err := NewURL("golang.org/x/crypto")
+	Expect(withAuthorityRepository2.String()).To(Equal("https://golang.org/x/crypto"))
+	Expect(withAuthorityRepository2.Host).To(Equal("golang.org"))
 	Expect(err).To(BeNil())
 
 	os.Setenv("GITHUB_USER", "ghq-test")

--- a/vcs.go
+++ b/vcs.go
@@ -110,3 +110,9 @@ var DarcsBackend = &VCSBackend{
 		return utils.RunInDir(local, "darcs", "pull")
 	},
 }
+
+var vcsBackendMap = map[string]*VCSBackend{
+	"git": GitBackend,
+	"hg":  MercurialBackend,
+	"svn": SubversionBackend,
+}


### PR DESCRIPTION
follow on #119

## Before

```console
% ghq get golang.org/x/crypto
     clone https://golang.org/x/crypto -> /Users/Songmu/dev/src/golang.org/x/crypto
       git ls-remote https://golang.org/x/crypto
        hg identify https://golang.org/x/crypto
       svn info https://golang.org/x/crypto
     error Could not find version control system: https://golang.org/x/crypto
```

## After

```console
$ ghq get golang.org/x/crypto
     clone https://golang.org/x/crypto -> /Users/Songmu/dev/src/golang.org/x/crypto
       git ls-remote https://golang.org/x/crypto
       git clone https://go.googlesource.com/crypto /Users/Songmu/dev/src/golang.org/x/crypto
Cloning into '/Users/Songmu/dev/src/golang.org/x/crypto'...
remote: Total 5013 (delta 2982), reused 5013 (delta 2982)
Receiving objects: 100% (5013/5013), 4.76 MiB | 7.54 MiB/s, done.
Resolving deltas: 100% (2982/2982), done.
```