### PR TITLE
Fix `ghq root`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -490,7 +490,11 @@ func doRoot(c *cli.Context) error {
 			fmt.Println(root)
 		}
 	} else {
-		fmt.Println(primaryLocalRepositoryRoot())
+		root, err := primaryLocalRepositoryRoot()
+		if err != nil {
+			return err
+		}
+		fmt.Println(root)
 	}
 	return nil
 }


### PR DESCRIPTION
`ghq root` got broken by 0d1c965 which changed the return value of
primaryLocalRepositoryRoot().

```shell-session
% ghq root
/home/knu/src <nil>
```