### PR TITLE
remove ghq.import.<subcommand> feature

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -415,49 +414,6 @@ func doImport(c *cli.Context) error {
 		isSilent = true
 	}
 
-	var (
-		in       io.Reader
-		finalize func() error
-	)
-
-	if len(c.Args()) == 0 {
-		// `ghq import` reads URLs from stdin
-		in = os.Stdin
-		finalize = func() error { return nil }
-	} else {
-		// Handle `ghq import starred motemen` case
-		// with `git config --global ghq.import.starred "!github-list-starred"`
-		subCommand := c.Args().First()
-		command, err := GitConfigSingle("ghq.import." + subCommand)
-		if err == nil && command == "" {
-			err = fmt.Errorf("ghq.import.%s configuration not found", subCommand)
-		}
-		if err != nil {
-			return err
-		}
-
-		// execute `sh -c 'COMMAND "$@"' -- ARG...`
-		// TODO: Windows
-		command = strings.TrimLeft(command, "!")
-		shellCommand := append([]string{"sh", "-c", command + ` "$@"`, "--"}, c.Args().Tail()...)
-
-		logger.Log("run", strings.Join(append([]string{command}, c.Args().Tail()...), " "))
-
-		cmd := exec.Command(shellCommand[0], shellCommand[1:]...)
-		cmd.Stderr = os.Stderr
-
-		in, err = cmd.StdoutPipe()
-		if err != nil {
-			return err
-		}
-
-		if err := cmd.Start(); err != nil {
-			return err
-		}
-
-		finalize = cmd.Wait
-	}
-
 	processLine := func(line string) error {
 		url, err := NewURL(line)
 		if err != nil {
@@ -492,7 +448,7 @@ func doImport(c *cli.Context) error {
 		eg = &errgroup.Group{}
 		sem = make(chan struct{}, 6)
 	}
-	scanner := bufio.NewScanner(in)
+	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if parallel {
@@ -515,7 +471,7 @@ func doImport(c *cli.Context) error {
 			logger.Log("error", err.Error())
 		}
 	}
-	return finalize()
+	return nil
 }
 
 func doRoot(c *cli.Context) error {

--- a/ghq.txt
+++ b/ghq.txt
@@ -51,11 +51,7 @@ look::
 
 import::
     If no extra arguments given, reads repository URLs from stdin line by line
-    and performs 'get' for each of them. +
-    If given a subcommand name e.g. 'ghq import <subcommand> [<args>...]',
-    ghq looks up a configuration 'ghq.import.<subcommand>' for a command, invokes
-    it, and uses its output as URLs list. See below for 'ghq.import.<subcommand>'
-    in CONFIGURATION section.
+    and performs 'get' for each of them.
 
 root::
     Prints repositories' root (i.e. `ghq.root`). Without '--all' option, the
@@ -87,21 +83,6 @@ ghq.<url>.vcs::
 [ghq "https://git.example.com/repos/"]
 vcs = git
 ....
-
-
-ghq.import.<subcommand>::
-    When 'import' is called with extra arguments e.g. 'ghq import <subcommand> [<args>...]',
-    first of them is treated as a subcommand name and this configuration value
-    will be used for a command. The command is invoked with rest arguments
-    and expected to print remote repository URLs line by line. +
-    For example with https://github.com/motemen/github-list-starred[github-list-starred]:
-
-....
-# Invoke as `ghq import starred motemen`
-[ghq "import"]
-starred = github-list-starred
-....
-
 
 ghq.ghe.host::
     The hostname of your GitHub Enterprise installation. A repository that has a


### PR DESCRIPTION
It seems that few people use this function, and I think that it is better to accept URL list from standard input only. That's less code and simpler.

How do you think? @motemen 