### PR TITLE
remove extra / from ref when path has "/" prefix

### DIFF
--- a/url.go
+++ b/url.go
@@ -28,7 +28,11 @@ func newURL(ref string) (*url.URL, error) {
 			host := matched[2]
 			path := matched[3]
 
-			ref = fmt.Sprintf("ssh://%s%s/%s", user, host, path)
+			if strings.HasPrefix(path, "/") {
+				ref = fmt.Sprintf("ssh://%s%s%s", user, host, path)
+			} else {
+				ref = fmt.Sprintf("ssh://%s%s/%s", user, host, path)
+			}
 		} else {
 			// If ref is like "github.com/motemen/ghq" convert to "https://github.com/motemen/ghq"
 			paths := strings.Split(ref, "/")

--- a/url.go
+++ b/url.go
@@ -27,12 +27,12 @@ func newURL(ref string) (*url.URL, error) {
 			user := matched[1]
 			host := matched[2]
 			path := matched[3]
-
-			if strings.HasPrefix(path, "/") {
-				ref = fmt.Sprintf("ssh://%s%s%s", user, host, path)
-			} else {
-				ref = fmt.Sprintf("ssh://%s%s/%s", user, host, path)
-			}
+			// If the path is a relative path not beginning with a slash like
+			// `path/to/repo`, we might convert to like
+			// `ssh://user@repo.example.com/~/path/to/repo` using tilde, but
+			// since GitHub doesn't support it, we treat relative and absolute
+			// paths the same way.
+			ref = fmt.Sprintf("ssh://%s%s/%s", user, host, strings.TrimPrefix(path, "/"))
 		} else {
 			// If ref is like "github.com/motemen/ghq" convert to "https://github.com/motemen/ghq"
 			paths := strings.Split(ref, "/")

--- a/url_test.go
+++ b/url_test.go
@@ -28,7 +28,7 @@ func TestNewURL(t *testing.T) {
 	}, {
 		name:   "scp with root",
 		url:    "git@github.com:/motemen/pusheen-explorer.git",
-		expect: "ssh://git@github.com//motemen/pusheen-explorer.git",
+		expect: "ssh://git@github.com/motemen/pusheen-explorer.git",
 		host:   "github.com",
 	}, {
 		name:   "scp without user",


### PR DESCRIPTION
ghq fails to clone some repo like "git@example.com:/foo/bar.git".