### PR TITLE
even if the GHQ_ROOT directory doesn't exist, don't raise an error

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -205,6 +205,9 @@ func walkLocalRepositories(callback func(*LocalRepository)) error {
 	for _, root := range roots {
 		if err := filepath.Walk(root, func(fpath string, fi os.FileInfo, err error) error {
 			if err != nil || fi == nil {
+				if err == nil || os.IsNotExist(err) {
+					return nil
+				}
 				return err
 			}
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {


### PR DESCRIPTION
ref #165

On my second thought, I rollbacked to previous behavior.