### PR TITLE
[fix] Fix the list if symlink is in the same directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
 - 1.x
-- tip
 script:
 - make test VERBOSE=1
 after_script:

--- a/local_repository.go
+++ b/local_repository.go
@@ -216,17 +216,16 @@ func walkLocalRepositories(callback func(*LocalRepository)) error {
 				if err != nil {
 					return nil
 				}
-			}
-			if !fi.IsDir() {
-				return nil
-			}
-			vcsBackend := findVCSBackend(fpath)
-			if vcsBackend == nil {
+				repo := LocalRepositoryFromFile(fpath, fi)
+				if repo == nil {
+					return nil
+				}
+				callback(repo)
 				return nil
 			}
 
-			repo, err := LocalRepositoryFromFullPath(fpath, vcsBackend)
-			if err != nil || repo == nil {
+			repo := LocalRepositoryFromFile(fpath, fi)
+			if repo == nil {
 				return nil
 			}
 			callback(repo)
@@ -236,6 +235,24 @@ func walkLocalRepositories(callback func(*LocalRepository)) error {
 		}
 	}
 	return nil
+}
+
+func LocalRepositoryFromFile(fpath string, fi os.FileInfo) *LocalRepository {
+	if !fi.IsDir() {
+		return nil
+	}
+
+	vcsBackend := findVCSBackend(fpath)
+	if vcsBackend == nil {
+		return nil
+	}
+
+	repo, err := LocalRepositoryFromFullPath(fpath, vcsBackend)
+	if err != nil || repo == nil {
+		return nil
+	}
+
+	return repo
 }
 
 var _localRepositoryRoots []string


### PR DESCRIPTION
Fix the list if symlink is in the same directory.

## test dir

```
$ pwd
/tmp/ghq_test
$ tree -a -L 3
.
├── main_dir
│   ├── a_dir
│   │   └── .git
│   ├── h_dir -> /tmp/ghq_test/sym_dir/h_dir/
│   └── z_dir
│       └── .git
└── sym_dir
    └── h_dir
        └── .git

9 directories, 0 files
```

## ghq root

```
$ ghq root
/tmp/ghq_test
```

## test

### before (latest version)

```
$ ghq -v
ghq version 0.12.2 (rev:6e7f3c8)
$ ghq list
main_dir/a_dir
main_dir/h_dir
sym_dir/h_dir
```

`main_dir/z_dir` is not found.

### after (this PR version)

setup.

```
$ pwd
/path/to/github.com/at-grandpa/ghq
$ git branch
* fix-list-symlink-in-same-directory
  master
$ make build
go get  -d
go mod tidy
go build  -ldflags="-s -w -X main.revision=360ea7a"
```

`ghq list`.

```
$ ./ghq list
main_dir/a_dir
main_dir/h_dir
main_dir/z_dir
sym_dir/h_dir
```

`main_dir/z_dir` is found.

## Why?

If `filepath.Walk` returns `filepath.SkipDir` at symlink time, it will not reference subsequent files in the same directory. Therefore, it was not output to the list. So I have decided not to return `filepath.SkipDir` for symlinks.