### PR TITLE
Removing port number from local directory.

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -130,7 +130,7 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 			strings.TrimSuffix(remoteURL.Path, ".git"),
 			strings.TrimSuffix(repoURL.Path, ".git"))
 		if l != "" {
-			localRepoRoot = path.Join(local.RootPath, remoteURL.Host, l)
+			localRepoRoot = path.Join(local.RootPath, remoteURL.Hostname(), l)
 		}
 
 		if getRepoLock(localRepoRoot) {

--- a/local_repository.go
+++ b/local_repository.go
@@ -66,7 +66,7 @@ func LocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRe
 
 func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 	pathParts := append(
-		[]string{remoteURL.Host}, strings.Split(remoteURL.Path, "/")...,
+		[]string{remoteURL.Hostname()}, strings.Split(remoteURL.Path, "/")...,
 	)
 	relPath := strings.TrimSuffix(path.Join(pathParts...), ".git")
 	pathParts[len(pathParts)-1] = strings.TrimSuffix(pathParts[len(pathParts)-1], ".git")

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -83,6 +83,10 @@ func TestNewLocalRepository(t *testing.T) {
 		name:   "git Assembla",
 		url:    "https://git.assembla.com/ghq.git",
 		expect: filepath.Join(tmproot, "git.assembla.com/ghq"),
+	}, {
+		name:   "bitbucket host with port",
+		url:    "https://bitbucket.local:8888/motemen/ghq.git",
+		expect: filepath.Join(tmproot, "bitbucket.local/motemen/ghq"),
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Overview
This change caused port numbers to be removed from the created local directory

#### ex)  
example.com:8888/hoge/fuga
↓
local directory
before) example.com:8888/hoge/fuga
after) example.com/hoge/fuga

### Motivation
Directory path is generally separated colon.  
In the case of directory with port, directory loading fails  in some case.