### PR TITLE
Use filepath

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -207,7 +208,7 @@ func doLook(c *cli.Context) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = repo.FullPath
-		cmd.Env = append(os.Environ(), "GHQ_LOOK="+repo.RelPath)
+		cmd.Env = append(os.Environ(), "GHQ_LOOK="+filepath.ToSlash(repo.RelPath))
 		return cmdutil.RunCommand(cmd, true)
 	default:
 		b := &strings.Builder{}

--- a/getter.go
+++ b/getter.go
@@ -47,7 +47,7 @@ func (g *getter) get(argURL string) error {
 			for _, r := range roots {
 				p := strings.TrimPrefix(path, r+string(filepath.Separator))
 				if p != path && (localRepoRoot == "" || len(p) < len(localRepoRoot)) {
-					localRepoRoot = p
+					localRepoRoot = filepath.ToSlash(p)
 				}
 			}
 
@@ -130,7 +130,7 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 			strings.TrimSuffix(remoteURL.Path, ".git"),
 			strings.TrimSuffix(repoURL.Path, ".git"))
 		if l != "" {
-			localRepoRoot = path.Join(local.RootPath, remoteURL.Hostname(), l)
+			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
 		}
 
 		if getRepoLock(localRepoRoot) {

--- a/import_test.go
+++ b/import_test.go
@@ -52,7 +52,7 @@ func TestDoImport(t *testing.T) {
 				}
 				log := buf.String()
 				for _, r := range in {
-					if !strings.Contains(log, r) {
+					if !strings.Contains(log, filepath.FromSlash(r)) {
 						t.Errorf("log should contains %q but not: %s", r, log)
 					}
 				}

--- a/local_repository.go
+++ b/local_repository.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -68,7 +67,7 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 	pathParts := append(
 		[]string{remoteURL.Hostname()}, strings.Split(remoteURL.Path, "/")...,
 	)
-	relPath := strings.TrimSuffix(path.Join(pathParts...), ".git")
+	relPath := strings.TrimSuffix(filepath.Join(pathParts...), ".git")
 	pathParts[len(pathParts)-1] = strings.TrimSuffix(pathParts[len(pathParts)-1], ".git")
 
 	var localRepository *LocalRepository
@@ -92,7 +91,7 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 	}
 	// No local repository found, returning new one
 	return &LocalRepository{
-		FullPath:  path.Join(prim, relPath),
+		FullPath:  filepath.Join(prim, relPath),
 		RelPath:   relPath,
 		RootPath:  prim,
 		PathParts: pathParts,

--- a/local_repository.go
+++ b/local_repository.go
@@ -56,7 +56,7 @@ func LocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRe
 
 	return &LocalRepository{
 		FullPath:   fullPath,
-		RelPath:    filepath.ToSlash(relPath),
+		RelPath:    relPath,
 		RootPath:   root,
 		PathParts:  pathParts,
 		vcsBackend: backend,
@@ -92,7 +92,7 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 	// No local repository found, returning new one
 	return &LocalRepository{
 		FullPath:  filepath.Join(prim, relPath),
-		RelPath:   filepath.ToSlash(relPath),
+		RelPath:   relPath,
 		RootPath:  prim,
 		PathParts: pathParts,
 	}, nil

--- a/local_repository.go
+++ b/local_repository.go
@@ -92,7 +92,7 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 	// No local repository found, returning new one
 	return &LocalRepository{
 		FullPath:  filepath.Join(prim, relPath),
-		RelPath:   relPath,
+		RelPath:   filepath.ToSlash(relPath),
 		RootPath:  prim,
 		PathParts: pathParts,
 	}, nil


### PR DESCRIPTION
Current implementation crash on tests.
```
=== RUN   TestCommandGet
=== RUN   TestCommandGet/simple
     clone https://github.com/motemen/ghq-test-repo -> C:\Users\mattn\AppData\Local\Temp\ghq-test410163495/github.com/motemen/ghq-test-repo
=== RUN   TestCommandGet/-p_option
     clone ssh://git@github.com/motemen/ghq-test-repo -> C:\Users\mattn\AppData\Local\Temp\ghq-test612581466/github.com/motemen/ghq-test-repo
=== RUN   TestCommandGet/already_cloned_with_-u
    update C:\Users\mattn\AppData\Local\Temp\ghq-test417289713\github.com\motemen\ghq-test-repo
=== RUN   TestCommandGet/shallow
     clone https://github.com/motemen/ghq-test-repo -> C:\Users\mattn\AppData\Local\Temp\ghq-test767359132/github.com/motemen/ghq-test-repo
=== RUN   TestCommandGet/dot_slach_./
  resolved relative ".\\ghq-test-repo" to "https://github.com\\motemen\\ghq-test-repo"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x8 pc=0x580d51]

goroutine 21 [running]:
testing.tRunner.func1(0xc000156300)
	C:/go/src/testing/testing.go:874 +0x3aa
panic(0x810dc0, 0xbc0920)
	C:/go/src/runtime/panic.go:679 +0x1c0
net/url.(*URL).String(0x0, 0xc000127100, 0x4)
	C:/go/src/net/url/url.go:777 +0x51
github.com/motemen/ghq.TestCommandGet.func5(0xc000156300, 0xc000172300, 0x35, 0xc000105dc0, 0xc0001167c0)
	C:/Users/mattn/go/src/github.com/motemen/ghq/commands_test.go:163 +0x20b
github.com/motemen/ghq.withFakeGitBackend(0xc000156300, 0xc000037080)
	C:/Users/mattn/go/src/github.com/motemen/ghq/commands_test.go:70 +0x31f
github.com/motemen/ghq.TestCommandGet.func7(0xc000156300)
	C:/Users/mattn/go/src/github.com/motemen/ghq/commands_test.go:197 +0x3f
testing.tRunner(0xc000156300, 0xc000116770)
	C:/go/src/testing/testing.go:909 +0xd0
created by testing.(*T).Run
	C:/go/src/testing/testing.go:960 +0x358
exit status 2
FAIL	github.com/motemen/ghq	0.231s
```