### PR TITLE
Add ghq.findVcs for speedup of ghq list

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,6 +84,18 @@ ghq.<url>.vcs::
 vcs = git
 ....
 
+ghq.findVcs::
+    'ghq list' checks each directory under ghq.root to see which VCS is used.
+    With this option you can make 'ghq list' check only the VCS using. +
+    Acceptable values are the same as ghq.<url>.vcs. +
+    For example in .gitconfig:
+
+....
+[ghq]
+findVcs = git
+findVcs = mercurial
+....
+
 ghq.ghe.host::
     The hostname of your GitHub Enterprise installation. A repository that has a
     hostname set with this key will be regarded as same one as one on GitHub.

--- a/vcs.go
+++ b/vcs.go
@@ -29,6 +29,8 @@ type VCSBackend struct {
 	Clone func(*url.URL, string, bool, bool) error
 	// Updates a cloned local repository.
 	Update func(string, bool) error
+	// Returns VCS specific files
+	Contents func() []string
 }
 
 var GitBackend = &VCSBackend{
@@ -51,6 +53,9 @@ var GitBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "git", "pull", "--ff-only")
 	},
+	Contents: func() []string {
+		return []string{".git"}
+	},
 }
 
 var SubversionBackend = &VCSBackend{
@@ -72,6 +77,9 @@ var SubversionBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "svn", "update")
 	},
+	Contents: func() []string {
+		return []string{".svn"}
+	},
 }
 
 var GitsvnBackend = &VCSBackend{
@@ -88,6 +96,9 @@ var GitsvnBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "git", "svn", "rebase")
 	},
+	Contents: func() []string {
+		return []string{".git/svn"}
+	},
 }
 
 var MercurialBackend = &VCSBackend{
@@ -103,6 +114,9 @@ var MercurialBackend = &VCSBackend{
 	},
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "hg", "pull", "--update")
+	},
+	Contents: func() []string {
+		return []string{".hg"}
 	},
 }
 
@@ -125,6 +139,9 @@ var DarcsBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "darcs", "pull")
 	},
+	Contents: func() []string {
+		return []string{"_darcs"}
+	},
 }
 
 var cvsDummyBackend = &VCSBackend{
@@ -133,6 +150,9 @@ var cvsDummyBackend = &VCSBackend{
 	},
 	Update: func(local string, silent bool) error {
 		return errors.New("CVS update is not supported")
+	},
+	Contents: func() []string {
+		return []string{"CVS/Repository"}
 	},
 }
 
@@ -152,6 +172,9 @@ var FossilBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "fossil", "update")
 	},
+	Contents: func() []string {
+		return []string{".fslckout", "_FOSSIL_"}
+	},
 }
 
 var BazaarBackend = &VCSBackend{
@@ -167,6 +190,9 @@ var BazaarBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		// Without --overwrite bzr will not pull tags that changed.
 		return runInDir(silent)(local, "bzr", "pull", "--overwrite")
+	},
+	Contents: func() []string {
+		return []string{".bzr"}
 	},
 }
 


### PR DESCRIPTION
`ghq list` checks all supported VCS content in string length order.
This causes `ghq list` to be slow for users who only use certain VCSs (Especially for git and/or mercurial only).

To solve this, I added a new configuration value `ghq.findVcs`.
If nothing is set, it works as before (See README.adoc changes for details.).

In my envrionment (git repositories only), this reduce about 200 - 300ms.

Before (fe5ca05)
```
$ time ghq list >/dev/null

real    0m0.844s
user    0m0.786s
sys     0m1.885s
```

After (2d50dcd and `git config --global ghq.findVcs git`)
```
$ time ghq list >/dev/null

real    0m0.554s
user    0m0.580s
sys     0m1.096s
```

If the name `findVcs` is not good, please give me a good idea.
