### PR TITLE
Add --branch option to `ghq get` for specifying branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ You can also list local repositories (+ghq list+), jump into local repositories 
 == SYNOPSIS
 
 [verse]
-ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
+ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] [--branch] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
 ghq list [-p] [-e] [<query>]
 ghq look (<project> | <path/to/project> | <host>/<user>/<project> | <repository URL>)
 ghq import [-u] [-p] [--shalow] [--vcs] [--parallel] < FILE
@@ -33,10 +33,13 @@ get::
     If there are multiple +ghq.root+ s, existing local clones are searched
     first. Then a new repository clone is created under the primary root if
     none is found. +
-    With '-shallow' option, a "shallow clone" will be performed (for Git
+    With '--shallow' option, a "shallow clone" will be performed (for Git
     repositories only, 'git clone --depth 1 ...' eg.). Be careful that a
-    shallow-cloned repository cannot be pushed to remote. +
-    Currently Git and Mercurial repositories are supported.
+    shallow-cloned repository cannot be pushed to remote.
+    Currently Git and Mercurial repositories are supported. +
+    With '--branch' option, you can clone the repository with specified
+    repository. This option is currently supported for Git, Mercurial,
+    Subversion and git-svn.
 
 list::
     List locally cloned repositories. If a query argument is given, only

--- a/commands.go
+++ b/commands.go
@@ -29,6 +29,7 @@ var cloneFlags = []cli.Flag{
 	&cli.BoolFlag{Name: "look, l", Usage: "Look after get"},
 	&cli.StringFlag{Name: "vcs", Usage: "Specify VCS backend for cloning"},
 	&cli.BoolFlag{Name: "silent, s", Usage: "clone or update silently"},
+	&cli.StringFlag{Name: "branch, b", Usage: "Specify branch name. This flag implies --single-branch on Git"},
 }
 
 var commandGet = cli.Command{
@@ -140,6 +141,7 @@ func doGet(c *cli.Context) error {
 		ssh:     c.Bool("p"),
 		vcs:     c.String("vcs"),
 		silent:  c.Bool("silent"),
+		branch:  c.String("branch"),
 	}
 
 	if argURL == "" {

--- a/getter.go
+++ b/getter.go
@@ -28,7 +28,7 @@ func getRepoLock(localRepoRoot string) bool {
 
 type getter struct {
 	update, shallow, silent, ssh bool
-	vcs                          string
+	vcs, branch                  string
 }
 
 func (g *getter) get(argURL string) error {
@@ -135,7 +135,7 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 		}
 
 		if getRepoLock(localRepoRoot) {
-			return vcs.Clone(repoURL, localRepoRoot, g.shallow, g.silent)
+			return vcs.Clone(repoURL, localRepoRoot, g.shallow, g.silent, g.branch)
 		}
 		return nil
 	}

--- a/vcs.go
+++ b/vcs.go
@@ -69,6 +69,8 @@ var SubversionBackend = &VCSBackend{
 			args = append(args, "--depth", "1")
 		}
 		if branch != "" {
+			copied := *remote
+			remote = &copied
 			remote.Path += "/branches/" + url.PathEscape(branch)
 		}
 		args = append(args, remote.String(), local)
@@ -89,6 +91,8 @@ var GitsvnBackend = &VCSBackend{
 			return err
 		}
 		if branch != "" {
+			copied := *remote
+			remote = &copied
 			remote.Path += "/branches/" + url.PathEscape(branch)
 		}
 
@@ -107,10 +111,11 @@ var MercurialBackend = &VCSBackend{
 		if err != nil {
 			return err
 		}
-		args := []string{"clone", remote.String(), local}
+		args := []string{"clone"}
 		if branch != "" {
 			args = append(args, "--branch", branch)
 		}
+		args = append(args, remote.String(), local)
 
 		return run(silent)("hg", args...)
 	},

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -34,15 +34,21 @@ func TestVCSBackend(t *testing.T) {
 	}{{
 		name: "[git] clone",
 		f: func() error {
-			return GitBackend.Clone(remoteDummyURL, localDir, false, false)
+			return GitBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"git", "clone", remoteDummyURL.String(), localDir},
 	}, {
 		name: "[git] shallow clone",
 		f: func() error {
-			return GitBackend.Clone(remoteDummyURL, localDir, true, true)
+			return GitBackend.Clone(remoteDummyURL, localDir, true, true, "")
 		},
 		expect: []string{"git", "clone", "--depth", "1", remoteDummyURL.String(), localDir},
+	}, {
+		name: "[git] clone specific branch",
+		f: func() error {
+			return GitBackend.Clone(remoteDummyURL, localDir, false, false, "hello")
+		},
+		expect: []string{"git", "clone", "--branch", "hello", "--single-branch", remoteDummyURL.String(), localDir},
 	}, {
 		name: "[git] update",
 		f: func() error {
@@ -53,15 +59,21 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[svn] checkout",
 		f: func() error {
-			return SubversionBackend.Clone(remoteDummyURL, localDir, false, false)
+			return SubversionBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"svn", "checkout", remoteDummyURL.String(), localDir},
 	}, {
 		name: "[svn] checkout shallow",
 		f: func() error {
-			return SubversionBackend.Clone(remoteDummyURL, localDir, true, false)
+			return SubversionBackend.Clone(remoteDummyURL, localDir, true, false, "")
 		},
 		expect: []string{"svn", "checkout", "--depth", "1", remoteDummyURL.String(), localDir},
+	}, {
+		name: "[svn] checkout specific branch",
+		f: func() error {
+			return SubversionBackend.Clone(remoteDummyURL, localDir, false, false, "hello")
+		},
+		expect: []string{"svn", "checkout", remoteDummyURL.String() + "/branches/hello", localDir},
 	}, {
 		name: "[svn] update",
 		f: func() error {
@@ -72,7 +84,7 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[git-svn] clone",
 		f: func() error {
-			return GitsvnBackend.Clone(remoteDummyURL, localDir, false, false)
+			return GitsvnBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"git", "svn", "clone", remoteDummyURL.String(), localDir},
 	}, {
@@ -85,13 +97,19 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[git-svn] clone shallow",
 		f: func() error {
-			return GitsvnBackend.Clone(remoteDummyURL, localDir, true, false)
+			return GitsvnBackend.Clone(remoteDummyURL, localDir, true, false, "")
 		},
 		expect: []string{"git", "svn", "clone", remoteDummyURL.String(), localDir},
 	}, {
+		name: "[git-svn] clone specific branch",
+		f: func() error {
+			return GitsvnBackend.Clone(remoteDummyURL, localDir, false, false, "hello")
+		},
+		expect: []string{"git", "svn", "clone", remoteDummyURL.String() + "/branches/hello", localDir},
+	}, {
 		name: "[hg] clone",
 		f: func() error {
-			return MercurialBackend.Clone(remoteDummyURL, localDir, false, false)
+			return MercurialBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"hg", "clone", remoteDummyURL.String(), localDir},
 	}, {
@@ -104,19 +122,25 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[hg] clone shallow",
 		f: func() error {
-			return MercurialBackend.Clone(remoteDummyURL, localDir, true, false)
+			return MercurialBackend.Clone(remoteDummyURL, localDir, true, false, "")
 		},
 		expect: []string{"hg", "clone", remoteDummyURL.String(), localDir},
 	}, {
+		name: "[hg] clone specific branch",
+		f: func() error {
+			return MercurialBackend.Clone(remoteDummyURL, localDir, false, false, "hello")
+		},
+		expect: []string{"hg", "clone", "--branch", "hello", remoteDummyURL.String(), localDir},
+	}, {
 		name: "[darcs] clone",
 		f: func() error {
-			return DarcsBackend.Clone(remoteDummyURL, localDir, false, false)
+			return DarcsBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"darcs", "get", remoteDummyURL.String(), localDir},
 	}, {
 		name: "[darcs] clone shallow",
 		f: func() error {
-			return DarcsBackend.Clone(remoteDummyURL, localDir, true, false)
+			return DarcsBackend.Clone(remoteDummyURL, localDir, true, false, "")
 		},
 		expect: []string{"darcs", "get", "--lazy", remoteDummyURL.String(), localDir},
 	}, {
@@ -129,7 +153,7 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[bzr] clone",
 		f: func() error {
-			return BazaarBackend.Clone(remoteDummyURL, localDir, false, false)
+			return BazaarBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"bzr", "branch", remoteDummyURL.String(), localDir},
 	}, {
@@ -142,13 +166,13 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[bzr] clone shallow",
 		f: func() error {
-			return BazaarBackend.Clone(remoteDummyURL, localDir, true, false)
+			return BazaarBackend.Clone(remoteDummyURL, localDir, true, false, "")
 		},
 		expect: []string{"bzr", "branch", remoteDummyURL.String(), localDir},
 	}, {
 		name: "[fossil] clone",
 		f: func() error {
-			return FossilBackend.Clone(remoteDummyURL, localDir, false, false)
+			return FossilBackend.Clone(remoteDummyURL, localDir, false, false, "")
 		},
 		expect: []string{"fossil", "open", fossilRepoName},
 		dir:    localDir,
@@ -182,15 +206,33 @@ func TestCvsDummyBackend(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	localDir := filepath.Join(tempDir, "repo")
 
-	if err := cvsDummyBackend.Clone(remoteDummyURL, localDir, false, false); err == nil {
+	if err := cvsDummyBackend.Clone(remoteDummyURL, localDir, false, false, ""); err == nil {
 		t.Error("error should be occurred, but nil")
 	}
 
-	if err := cvsDummyBackend.Clone(remoteDummyURL, localDir, true, false); err == nil {
+	if err := cvsDummyBackend.Clone(remoteDummyURL, localDir, true, false, ""); err == nil {
 		t.Error("error should be occurred, but nil")
 	}
 
 	if err := cvsDummyBackend.Update(localDir, false); err == nil {
+		t.Error("error should be occurred, but nil")
+	}
+}
+
+func TestBranchOptionIgnoredErrors(t *testing.T) {
+	tempDir := newTempDir(t)
+	defer os.RemoveAll(tempDir)
+	localDir := filepath.Join(tempDir, "repo")
+
+	if err := DarcsBackend.Clone(remoteDummyURL, localDir, false, false, "hello"); err == nil {
+		t.Error("error should be occurred, but nil")
+	}
+
+	if err := FossilBackend.Clone(remoteDummyURL, localDir, false, false, "hello"); err == nil {
+		t.Error("error should be occurred, but nil")
+	}
+
+	if err := BazaarBackend.Clone(remoteDummyURL, localDir, false, false, "hello"); err == nil {
 		t.Error("error should be occurred, but nil")
 	}
 }


### PR DESCRIPTION
Hi,

this patch adds `--branch` option to `ghq get`. Sample usage as follows:

```
ghq get --branch release/9.x https://github.com/llvm/llvm-project.git
```

This option clones a remote repository specifying a branch rather than the default branch. With Git, it also implies `--single-branch` to reduce time and amount of transferred objects.

This option is useful when you're working on large repository with many branches. For example, you may fork a large repository (e.g. DefinitelyTyped) and want only your PR branch in local.