### PR TITLE
optimize `--vcs` option of list

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -181,7 +181,7 @@ func doLook(c *cli.Context) error {
 		reposFound []*LocalRepository
 		mu         sync.Mutex
 	)
-	if err := walkLocalRepositories(func(repo *LocalRepository) {
+	if err := walkAllLocalRepositories(func(repo *LocalRepository) {
 		if repo.Matches(name) {
 			mu.Lock()
 			reposFound = append(reposFound, repo)

--- a/list.go
+++ b/list.go
@@ -48,20 +48,13 @@ func doList(c *cli.Context) error {
 			}
 		}
 	}
-	filterByVCS := func(repo *LocalRepository) bool {
-		if vcsBackend == "" {
-			return true
-		}
-		vcs, _ := repo.VCS()
-		return vcsRegistry[vcsBackend] == vcs
-	}
 
 	var (
 		repos []*LocalRepository
 		mu    sync.Mutex
 	)
-	if err := walkLocalRepositories(func(repo *LocalRepository) {
-		if !filterByQuery(repo) || !filterByVCS(repo) {
+	if err := walkLocalRepositories(vcsBackend, func(repo *LocalRepository) {
+		if !filterByQuery(repo) {
 			return
 		}
 		mu.Lock()

--- a/vcs.go
+++ b/vcs.go
@@ -29,6 +29,8 @@ type VCSBackend struct {
 	Clone func(*url.URL, string, bool, bool, string) error
 	// Updates a cloned local repository.
 	Update func(string, bool) error
+	// Returns VCS specific files
+	Contents func() []string
 }
 
 var GitBackend = &VCSBackend{
@@ -53,6 +55,9 @@ var GitBackend = &VCSBackend{
 	},
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "git", "pull", "--ff-only")
+	},
+	Contents: func() []string {
+		return []string{".git"}
 	},
 }
 
@@ -80,6 +85,9 @@ var SubversionBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "svn", "update")
 	},
+	Contents: func() []string {
+		return []string{".svn"}
+	},
 }
 
 var GitsvnBackend = &VCSBackend{
@@ -101,6 +109,9 @@ var GitsvnBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "git", "svn", "rebase")
 	},
+	Contents: func() []string {
+		return []string{".git/svn"}
+	},
 }
 
 var MercurialBackend = &VCSBackend{
@@ -121,6 +132,9 @@ var MercurialBackend = &VCSBackend{
 	},
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "hg", "pull", "--update")
+	},
+	Contents: func() []string {
+		return []string{".hg"}
 	},
 }
 
@@ -147,6 +161,9 @@ var DarcsBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "darcs", "pull")
 	},
+	Contents: func() []string {
+		return []string{"_darcs"}
+	},
 }
 
 var cvsDummyBackend = &VCSBackend{
@@ -155,6 +172,9 @@ var cvsDummyBackend = &VCSBackend{
 	},
 	Update: func(local string, silent bool) error {
 		return errors.New("CVS update is not supported")
+	},
+	Contents: func() []string {
+		return []string{"CVS/Repository"}
 	},
 }
 
@@ -177,6 +197,9 @@ var FossilBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		return runInDir(silent)(local, "fossil", "update")
 	},
+	Contents: func() []string {
+		return []string{".fslckout", "_FOSSIL_"}
+	},
 }
 
 var BazaarBackend = &VCSBackend{
@@ -195,6 +218,9 @@ var BazaarBackend = &VCSBackend{
 	Update: func(local string, silent bool) error {
 		// Without --overwrite bzr will not pull tags that changed.
 		return runInDir(silent)(local, "bzr", "pull", "--overwrite")
+	},
+	Contents: func() []string {
+		return []string{".bzr"}
 	},
 }
 


### PR DESCRIPTION
This changes `ghq list --list` behaivor.
With `--vcs git`, `ghq list` checks only file of given vcs.
(Note: `--max-depth` is needed, but is not implmented yet)
See: https://github.com/motemen/ghq/pull/198#issuecomment-556833400
