### PR TITLE
Fix deprecation of urfave/cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func newApp() *cli.App {
 	app.Version = fmt.Sprintf("%s (rev:%s)", version, revision)
 	app.Authors = []cli.Author{
 		{
-			Name: "motemen",
+			Name:  "motemen",
 			Email: "motemen@gmail.com",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -28,8 +28,12 @@ func newApp() *cli.App {
 	app.Name = "ghq"
 	app.Usage = "Manage GitHub repository clones"
 	app.Version = fmt.Sprintf("%s (rev:%s)", version, revision)
-	app.Author = "motemen"
-	app.Email = "motemen@gmail.com"
+	app.Authors = []cli.Author{
+		{
+			Name: "motemen",
+			Email: "motemen@gmail.com",
+		},
+	}
 	app.Commands = commands
 	return app
 }


### PR DESCRIPTION
`app.Author` and `app.Email` is deprecated.  
see also: https://github.com/urfave/cli/blob/v1.22.2/app.go#L79