### PR TITLE
add --recursive option to `ghq get`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,10 +16,10 @@ You can also list local repositories (+ghq list+), jump into local repositories 
 == SYNOPSIS
 
 [verse]
-ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] [--branch] [--recursive] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
+ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] [--branch] [--no-recursive] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
 ghq list [-p] [-e] [<query>]
 ghq look (<project> | <path/to/project> | <host>/<user>/<project> | <repository URL>)
-ghq import [-u] [-p] [--shalow] [--vcs] [--parallel] < FILE
+ghq import [-u] [-p] [--shalow] [--vcs] [--silent] [--no-recursive] [--parallel] < FILE
 ghq root [--all]
 
 == COMMANDS
@@ -40,8 +40,8 @@ get::
     With '--branch' option, you can clone the repository with specified
     repository. This option is currently supported for Git, Mercurial,
     Subversion and git-svn. +
-    With '--recursive' option, initialize and clone submodule recursively ('git clone --recursive ...' eg.).
-    This option is currently supported only for Git 
+    The 'ghq' gets the git repository recursively by default. +
+    We can prevent it with '--no-recursive' option.
 
 list::
     List locally cloned repositories. If a query argument is given, only

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ You can also list local repositories (+ghq list+), jump into local repositories 
 == SYNOPSIS
 
 [verse]
-ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] [--branch] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
+ghq get [-u] [-p] [--shallow] [--vcs] [--look] [--silent] [--branch] [--recursive] (<repository URL> | <host>/<user>/<project> | <user>/<project> | <project>)
 ghq list [-p] [-e] [<query>]
 ghq look (<project> | <path/to/project> | <host>/<user>/<project> | <repository URL>)
 ghq import [-u] [-p] [--shalow] [--vcs] [--parallel] < FILE
@@ -39,7 +39,9 @@ get::
     Currently Git and Mercurial repositories are supported. +
     With '--branch' option, you can clone the repository with specified
     repository. This option is currently supported for Git, Mercurial,
-    Subversion and git-svn.
+    Subversion and git-svn. +
+    With '--recursive' option, initialize and clone submodule recursively ('git clone --recursive ...' eg.).
+    This option is currently supported only for Git 
 
 list::
     List locally cloned repositories. If a query argument is given, only

--- a/cmd_get.go
+++ b/cmd_get.go
@@ -12,13 +12,13 @@ func doGet(c *cli.Context) error {
 		andLook = c.Bool("look")
 	)
 	g := &getter{
-		update:  c.Bool("update"),
-		shallow: c.Bool("shallow"),
-		ssh:     c.Bool("p"),
-		vcs:     c.String("vcs"),
-		silent:  c.Bool("silent"),
-		branch:  c.String("branch"),
-		recursive:  c.Bool("recursive"),
+		update:    c.Bool("update"),
+		shallow:   c.Bool("shallow"),
+		ssh:       c.Bool("p"),
+		vcs:       c.String("vcs"),
+		silent:    c.Bool("silent"),
+		branch:    c.String("branch"),
+		recursive: !c.Bool("--no-recursive"),
 	}
 
 	if argURL == "" {

--- a/cmd_get.go
+++ b/cmd_get.go
@@ -18,6 +18,7 @@ func doGet(c *cli.Context) error {
 		vcs:     c.String("vcs"),
 		silent:  c.Bool("silent"),
 		branch:  c.String("branch"),
+		recursive:  c.Bool("recursive"),
 	}
 
 	if argURL == "" {

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -33,6 +33,9 @@ func TestCommandGet(t *testing.T) {
 				if cloneArgs.branch != "" {
 					t.Errorf("cloneArgs.branch should be empty")
 				}
+				if cloneArgs.recursive {
+					t.Errorf("cloneArgs.recursive should be false")
+				}
 			},
 		},
 		{
@@ -146,6 +149,20 @@ func TestCommandGet(t *testing.T) {
 				}
 				if cloneArgs.branch != expectBranch {
 					t.Errorf("got: %q, expect: %q", cloneArgs.branch, expectBranch)
+				}
+			},
+		},
+		{
+			name: "with --recursive option",
+			scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+				app.Run([]string{"", "get", "--recursive", "motemen/ghq-test-repo"})
+				
+				localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
+				if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+					t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+				}
+				if !cloneArgs.recursive {
+					t.Errorf("cloneArgs.recursive should be true")
 				}
 			},
 		},

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -33,8 +33,8 @@ func TestCommandGet(t *testing.T) {
 				if cloneArgs.branch != "" {
 					t.Errorf("cloneArgs.branch should be empty")
 				}
-				if cloneArgs.recursive {
-					t.Errorf("cloneArgs.recursive should be false")
+				if !cloneArgs.recursive {
+					t.Errorf("cloneArgs.recursive should be true")
 				}
 			},
 		},
@@ -153,16 +153,16 @@ func TestCommandGet(t *testing.T) {
 			},
 		},
 		{
-			name: "with --recursive option",
+			name: "with --no-recursive option",
 			scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
-				app.Run([]string{"", "get", "--recursive", "motemen/ghq-test-repo"})
-				
+				app.Run([]string{"", "get", "--no-recursive", "motemen/ghq-test-repo"})
+
 				localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
 				if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
 					t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
 				}
 				if !cloneArgs.recursive {
-					t.Errorf("cloneArgs.recursive should be true")
+					t.Errorf("cloneArgs.recursive should be false")
 				}
 			},
 		},

--- a/cmd_import.go
+++ b/cmd_import.go
@@ -13,11 +13,12 @@ import (
 func doImport(c *cli.Context) error {
 	var parallel = c.Bool("parallel")
 	g := &getter{
-		update:  c.Bool("update"),
-		shallow: c.Bool("shallow"),
-		ssh:     c.Bool("p"),
-		vcs:     c.String("vcs"),
-		silent:  c.Bool("silent"),
+		update:    c.Bool("update"),
+		shallow:   c.Bool("shallow"),
+		ssh:       c.Bool("p"),
+		vcs:       c.String("vcs"),
+		silent:    c.Bool("silent"),
+		recursive: !c.Bool("--no-recursive"),
 	}
 	if parallel {
 		// force silent in parallel import

--- a/commands.go
+++ b/commands.go
@@ -23,6 +23,7 @@ var cloneFlags = []cli.Flag{
 	&cli.BoolFlag{Name: "look, l", Usage: "Look after get"},
 	&cli.StringFlag{Name: "vcs", Usage: "Specify VCS backend for cloning"},
 	&cli.BoolFlag{Name: "silent, s", Usage: "clone or update silently"},
+	&cli.BoolFlag{Name: "no-recursive", Usage: "prevent recursive fetching"},
 }
 
 var commandGet = cli.Command{
@@ -36,8 +37,7 @@ var commandGet = cli.Command{
 `,
 	Action: doGet,
 	Flags: append(cloneFlags,
-		&cli.StringFlag{Name: "branch, b", Usage: "Specify branch name. This flag implies --single-branch on Git"},
-		&cli.BoolFlag{Name: "recursive", Usage: "This flag implies --recursive on Git"}),
+		&cli.StringFlag{Name: "branch, b", Usage: "Specify branch name. This flag implies --single-branch on Git"}),
 }
 
 var commandList = cli.Command{

--- a/commands.go
+++ b/commands.go
@@ -36,7 +36,8 @@ var commandGet = cli.Command{
 `,
 	Action: doGet,
 	Flags: append(cloneFlags,
-		&cli.StringFlag{Name: "branch, b", Usage: "Specify branch name. This flag implies --single-branch on Git"}),
+		&cli.StringFlag{Name: "branch, b", Usage: "Specify branch name. This flag implies --single-branch on Git"},
+		&cli.BoolFlag{Name: "recursive", Usage: "This flag implies --recursive on Git"}),
 }
 
 var commandList = cli.Command{

--- a/commands_test.go
+++ b/commands_test.go
@@ -12,6 +12,7 @@ type _cloneArgs struct {
 	local   string
 	shallow bool
 	branch  string
+	recursive  bool
 }
 
 type _updateArgs struct {
@@ -36,6 +37,7 @@ func withFakeGitBackend(t *testing.T, block func(*testing.T, string, *_cloneArgs
 				local:   filepath.FromSlash(vg.dir),
 				shallow: vg.shallow,
 				branch:  vg.branch,
+				recursive:  vg.recursive,
 			}
 			return nil
 		},

--- a/getter.go
+++ b/getter.go
@@ -26,7 +26,7 @@ func getRepoLock(localRepoRoot string) bool {
 }
 
 type getter struct {
-	update, shallow, silent, ssh bool
+	update, shallow, silent, ssh, recursive bool
 	vcs, branch                  string
 }
 
@@ -140,6 +140,7 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 				shallow: g.shallow,
 				silent:  g.silent,
 				branch:  g.branch,
+				recursive:  g.recursive,
 			})
 		}
 		return nil

--- a/vcs.go
+++ b/vcs.go
@@ -57,6 +57,9 @@ var GitBackend = &VCSBackend{
 		if vg.branch != "" {
 			args = append(args, "--branch", vg.branch, "--single-branch")
 		}
+		if vg.recursive {
+			args = append(args, "--recursive")
+		}
 		args = append(args, vg.url.String(), vg.dir)
 
 		return run(vg.silent)("git", args...)

--- a/vcs.go
+++ b/vcs.go
@@ -68,7 +68,14 @@ var GitBackend = &VCSBackend{
 		if _, err := os.Stat(filepath.Join(vg.dir, ".git/svn")); err == nil {
 			return GitsvnBackend.Update(vg)
 		}
-		return runInDir(vg.silent)(vg.dir, "git", "pull", "--ff-only")
+		err := runInDir(vg.silent)(vg.dir, "git", "pull", "--ff-only")
+		if err != nil {
+			return err
+		}
+		if vg.recursive {
+			return runInDir(vg.silent)(vg.dir, "git", "submodule", "update", "--init", "--recursive")
+		}
+		return nil
 	},
 	Contents: []string{".git"},
 }

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -71,6 +71,16 @@ func TestVCSBackend(t *testing.T) {
 		expect: []string{"git", "pull", "--ff-only"},
 		dir:    localDir,
 	}, {
+		name: "[git] recursive",
+		f: func() error {
+			return GitBackend.Clone(&vcsGetOption{
+				url:    remoteDummyURL,
+				dir:    localDir,
+				recursive: true,
+			})
+		},
+		expect: []string{"git", "clone", "--recursive", remoteDummyURL.String(), localDir},
+	},{
 		name: "[svn] checkout",
 		f: func() error {
 			return SubversionBackend.Clone(&vcsGetOption{


### PR DESCRIPTION
Hi,

I added --recursive option to `ghq get`.
Sample usage as follows:

```
ghq get git@github.com:moajo/test3.git --recursive
```

This option just adds `--recursive` to `git clone` command.
This feature only works with the GitBackend.

related to #185 