### PR TITLE
Add expand command

### DIFF
--- a/cmd_expand_test.go
+++ b/cmd_expand_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Songmu/gitconfig"
+	"github.com/motemen/ghq/cmdutil"
+)
+
+func TestDoExpand(t *testing.T) {
+	defer func(orig func(cmd *exec.Cmd) error) {
+		cmdutil.CommandRunner = orig
+	}(cmdutil.CommandRunner)
+	defer func(orig string) { _home = orig }(_home)
+	defer gitconfig.WithConfig(t, "")()
+	tmpd := newTempDir(t)
+	defer os.RemoveAll(tmpd)
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+	_localRepositoryRoots = []string{tmpd}
+
+	out, _, _ := capture(func() {
+		newApp().Run([]string{"", "expand", "motemen/ghqq"})
+	})
+	out = strings.TrimSpace(out)
+	wantDir := filepath.Join(tmpd, "github.com/motemen/ghqq")
+
+	if out != wantDir {
+		t.Errorf("cmd.Dir = %q, want: %q", out, wantDir)
+	}
+}

--- a/commands.go
+++ b/commands.go
@@ -9,6 +9,7 @@ import (
 
 var commands = []cli.Command{
 	commandGet,
+	commandExpand,
 	commandList,
 	commandLook,
 	commandImport,
@@ -109,6 +110,13 @@ var commandDocs = map[string]commandDoc{
 	"create": {"", "<project> | <user>/<project> | <host>/<user>/<project>"},
 }
 
+var commandExpand = cli.Command{
+	Name:   "expand",
+	Usage:  "Expand to relative path from root root",
+	Action: doExpand,
+	Flags:  []cli.Flag{},
+}
+
 // Makes template conditionals to generate per-command documents.
 func mkCommandsTemplate(genTemplate func(commandDoc) string) string {
 	template := "{{if false}}"
@@ -134,4 +142,23 @@ OPTIONS:
     {{range .Flags}}{{.}}
     {{end}}
 {{end}}`
+}
+
+func doExpand(c *cli.Context) error {
+	var (
+		name = c.Args().First()
+		w    = c.App.Writer
+	)
+	u, err := newURL(name, false, true)
+	if err != nil {
+		return err
+	}
+
+	localRepo, err := LocalRepositoryFromURL(u)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintln(w, localRepo.FullPath)
+	return err
 }


### PR DESCRIPTION
This is mostly similar to create command. But I want a command expainding abbreviation to full-path like below.

```
$ cd $(ghq expand motemen/ghq)
```
or
```
$ less $(ghq expand ghq)/README.md
```
