### PR TITLE
[incompatible] fix localRepositoryRoots order

### DIFF
--- a/cmd_root_test.go
+++ b/cmd_root_test.go
@@ -53,9 +53,10 @@ func TestDoRoot(t *testing.T) {
 		setup: func() func() {
 			orig := os.Getenv(envGhqRoot)
 			os.Setenv(envGhqRoot, "")
-			teardown := gitconfig.WithConfig(t, `[ghq]
-  root = /path/to/ghqroot11
+			teardown := gitconfig.WithConfig(t, `
+[ghq]
   root = /path/to/ghqroot12
+  root = /path/to/ghqroot11
 `)
 			return func() {
 				os.Setenv(envGhqRoot, orig)

--- a/local_repository.go
+++ b/local_repository.go
@@ -345,6 +345,12 @@ func localRepositoryRoots(all bool) ([]string, error) {
 		if err != nil && !gitconfig.IsNotFound(err) {
 			return nil, err
 		}
+		// reverse slice
+		for i := len(_localRepositoryRoots)/2 - 1; i >= 0; i-- {
+			opp := len(_localRepositoryRoots) - 1 - i
+			_localRepositoryRoots[i], _localRepositoryRoots[opp] =
+				_localRepositoryRoots[opp], _localRepositoryRoots[i]
+		}
 	}
 
 	if len(_localRepositoryRoots) == 0 {


### PR DESCRIPTION
ref. #239

The behavior was unintentionally changed in #228.
However, it is natural for gitconfig that the settings defined later overwrite the previous settings, so I make this behavior the default behavior.