### PR TITLE
Fix argument for look in get, to make `ghq get -look` work

### DIFF
--- a/cmd_get.go
+++ b/cmd_get.go
@@ -55,7 +55,7 @@ func doGet(c *cli.Context) error {
 	sem := make(chan struct{}, 6)
 	for scr.Scan() {
 		target := scr.Text()
-		if firstArg != "" {
+		if firstArg == "" {
 			firstArg = target
 		}
 		if parallel {


### PR DESCRIPTION
#263 

Currently `firstArg` was never filled, which causes `look` does nothing.

I confirmed simple `get -look` as `./ghq get -look mackerelio/mackerel-agent` now works as expected, but not checked all options, like `--parallel` or so.