### PR TITLE
Add options to zsh-completion

### DIFF
--- a/misc/zsh/_ghq
+++ b/misc/zsh/_ghq
@@ -18,14 +18,35 @@ function _ghq () {
                 (get)
                     _arguments -C \
                         '(-u --update)'{-u,--update}'[Update local repository if cloned already]' \
+                        '-p[Clone with SSH]' \
+                        '--shallow[Do a shallow clone]' \
+                        '(-l --look)'{-l,--look}'[Look after get]' \
+                        '--vcs[Specify vcs backend for cloning]' \
+                        '(-s --silent)'{-s,--silent}'[Clone or update silently]' \
+                        '--no-recursive[Prevent recursive fetching]' \
+                        '(-b --branch)'{-b,--branch}'[Specify branch name]' \
+                        '(-P --parallel)'{-P,--parallel}'[Import parallely]' \
                         '(-)*:: :->null_state' \
                         && ret=0
                     ;;
                 (list)
                     _arguments -C \
                         '(-e --exact)'{-e,--exact}'[Perform an exact match]' \
+                        '--vcs[Specify vcs backend for matching]' \
                         '(-p --full-path)'{-p,--full-path}'[Print full paths]' \
                         '--unique[Print unique subpaths]' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (root)
+                    _arguments -C \
+                        '--all[Show all roots]' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (create)
+                    _arguments -C \
+                        '--vcs[Specify vcs backend explicitly]' \
                         '(-)*:: :->null_state' \
                         && ret=0
                     ;;
@@ -59,4 +80,3 @@ __ghq_commands () {
 }
 
 _ghq "$@"
-


### PR DESCRIPTION
Hello

I added completion of cli options to zsh-completion.

```
$ ghq get -<TAB>
--branch        -b  -- Specify branch name
--look          -l  -- Look after get
--no-recursive      -- Prevent recursive fetching
--parallel      -P  -- Import parallely
--shallow           -- Do a shallow clone
--silent        -s  -- Clone or update silently
--update        -u  -- Update local repository if cloned already
--vcs               -- Specify vcs backend for cloning
-p                  -- Clone with SSH
```
